### PR TITLE
Fixed broken jQuery fetch

### DIFF
--- a/index.js
+++ b/index.js
@@ -107,7 +107,7 @@ const articleParser = async function (options, socket) {
   })
 
   // Inject jQuery - https://stackoverflow.com/a/50598512
-  const jquery = await page.evaluate(() => window.fetch('https://cdnjs.cloudflare.com/ajax/libs/jquery/3.4.1/jquery.min.js').then((res) => res.text()))
+  const jquery = await page.evaluate(() => window.fetch('https://code.jquery.com/jquery-3.5.1.min.js').then((res) => res.text()))
 
   const response = await page.goto(options.url, options.puppeteer.goto).catch(function () {
     return false


### PR DESCRIPTION
The existing link results in the following message: 

This site can’t provide a secure connectioncdnjs.cloudflare.com uses an unsupported protocol.
ERR_SSL_VERSION_OR_CIPHER_MISMATCH

Which breaks the fetch and the code breaks. 

Using this link instead fixes the issue.