### PR TITLE
Refactor parser request handling and lint script

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Web Page Inspection Tool. Sentiment Analysis, Keyword Extraction, Named Entity Recognition & Spell Check",
   "main": "index.js",
   "scripts": {
-    "lint": "./node_modules/.bin/eslint . --ext .json --ext .js --fix",
+    "lint": "npx eslint . --ext .json --ext .js --fix",
     "test": "node test.js"
   },
   "repository": {


### PR DESCRIPTION
## Summary
- default socket parameter and conditional lighthouse assignment
- use URL API for request filtering and ensure browser closes with `try/finally`
- switch ESLint script to `npx` to simplify tooling

## Testing
- `apt-get install -y chromium libatk1.0-0 libx11-xcb1 libgtk-3-0 libnss3 libgbm1 libasound2t64`
- `npm install`
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b80e1640808332ac5cc6f70d924420