### PR TITLE
refactor: migrate to ES modules

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,14 +26,14 @@ npm install horseman-article-parser --save
 ### Usage Example
 
 ```
-var parser = require('horseman-article-parser');
+import { parseArticle } from 'horseman-article-parser';
 
-var options = {
+const options = {
   url: "https://www.theguardian.com/politics/2018/sep/24/theresa-may-calls-for-immigration-based-on-skills-and-wealth",
   enabled: ['lighthouse', 'screenshot', 'links', 'sentiment', 'entities', 'spelling', 'keywords']
 }
 
-parser.parseArticle(options)
+parseArticle(options)
   .then(function (article) {
 
     var response = {

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -14,7 +14,7 @@ const compat = new FlatCompat({
 
 export default [
   {
-    ignores: ['eslint.config.mjs']
+    ignores: ['eslint.config.mjs', 'overrides/**']
   },
   ...compat.extends(
     'eslint:recommended',

--- a/helpers.js
+++ b/helpers.js
@@ -8,9 +8,9 @@
  *
  */
 
-const _ = require('lodash')
+import _ from 'lodash'
 
-module.exports.setDefaultOptions = function (options = {}) {
+export function setDefaultOptions (options = {}) {
   const defaults = {
     enabled: [],
     puppeteer: {
@@ -46,11 +46,11 @@ module.exports.setDefaultOptions = function (options = {}) {
   return _.defaultsDeep({}, options, defaults)
 }
 
-module.exports.capitalizeFirstLetter = function (string) {
+export function capitalizeFirstLetter (string) {
   return string.charAt(0).toUpperCase() + string.slice(1)
 }
 
-module.exports.toTitleCase = function (str) {
+export function toTitleCase (str) {
   return str.replace(/\w\S*/g, function (txt) {
     return txt.charAt(0).toUpperCase() + txt.substr(1).toLowerCase()
   })
@@ -61,7 +61,7 @@ const dbg = (debug) ? console.log : function () {}
 
 let cleanRules = []
 
-module.exports.setCleanRules = function (rules) {
+export function setCleanRules (rules) {
   cleanRules = rules
 }
 
@@ -73,7 +73,7 @@ module.exports.setCleanRules = function (rules) {
  *
  * @return {Void}
  **/
-module.exports.prepDocument = function (document) {
+export function prepDocument (document) {
   const frames = document.getElementsByTagName('frame')
   if (frames.length > 0) {
     let bestFrame = null
@@ -126,7 +126,7 @@ module.exports.prepDocument = function (document) {
  *
  * @return {jQuery}
  **/
-module.exports.grabArticle = function (document, preserveUnlikelyCandidates, regexps) {
+export function grabArticle (document, preserveUnlikelyCandidates, regexps) {
   /**
    * First, node prepping. Trash nodes that look cruddy (like ones with the class name "comment", etc), and turn divs
    * into P tags where they have been used inappropriately (as in, where they contain no other block level elements.)

--- a/keywordParser.js
+++ b/keywordParser.js
@@ -1,10 +1,10 @@
-const retext = require('retext')
-const nlcstToString = require('nlcst-to-string')
-const pos = require('retext-pos')
-const keywords = require('retext-keywords')
-const _ = require('lodash')
+import retext from 'retext'
+import nlcstToString from 'nlcst-to-string'
+import pos from 'retext-pos'
+import keywords from 'retext-keywords'
+import _ from 'lodash'
 
-module.exports = async function keywordParser (html, options = { maximum: 10 }) {
+export default async function keywordParser (html, options = { maximum: 10 }) {
   const file = await retext().use(pos).use(keywords, options).process(html)
 
   const keywordsArr = file.data.keywords.map(keyword => ({

--- a/lighthouse.js
+++ b/lighthouse.js
@@ -1,7 +1,7 @@
-const lighthouseImport = require('lighthouse')
+import lighthouseImport from 'lighthouse'
 const lighthouse = lighthouseImport.default || lighthouseImport
 
-module.exports = async function lighthouseAnalysis (browser, options, socket) {
+export default async function lighthouseAnalysis (browser, options, socket) {
   socket.emit('parse:status', 'Starting Lighthouse')
 
   const results = await lighthouse(options.url, {

--- a/package.json
+++ b/package.json
@@ -2,9 +2,10 @@
   "name": "horseman-article-parser",
   "version": "0.9.0",
   "description": "Web Page Inspection Tool. Sentiment Analysis, Keyword Extraction, Named Entity Recognition & Spell Check",
+  "type": "module",
   "main": "index.js",
   "scripts": {
-    "lint": "npx eslint . --ext .json --ext .js --fix",
+    "lint": "node ./node_modules/eslint/bin/eslint.js . --ext .json --ext .js --fix",
     "test": "node test.js"
   },
   "repository": {

--- a/test.js
+++ b/test.js
@@ -1,6 +1,6 @@
-const parser = require('./index.js')
-const fs = require('fs')
-const assert = require('assert')
+import { parseArticle } from './index.js'
+import fs from 'fs'
+import assert from 'assert'
 
 /** add some names | https://observablehq.com/@spencermountain/compromise-plugins */
 const testPlugin = function (Doc, world) {
@@ -48,7 +48,7 @@ const options = {
 
 ;(async () => {
   try {
-    const article = await parser.parseArticle(options)
+    const article = await parseArticle(options)
     assert.ok(article.title.text, 'article title missing')
 
     const response = {


### PR DESCRIPTION
## Summary
- convert project to native ES modules and replace CommonJS requires with import syntax
- update lint script and configuration for module format
- document ES module usage and adjust tests accordingly

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b8239841408332b9e92ef741e72808