### PR TITLE
Clean text before checking spelling

### DIFF
--- a/index.js
+++ b/index.js
@@ -9,7 +9,7 @@ import Sentiment from 'sentiment'
 import { htmlToText } from 'html-to-text'
 import nlp from 'compromise'
 import absolutify from 'absolutify'
-import { JSDOM } from 'jsdom'
+import { JSDOM, VirtualConsole } from 'jsdom'
 import jquery from 'jquery'
 import { createRequire } from 'module'
 import {
@@ -243,7 +243,9 @@ const articleParser = async function (browser, options, socket) {
     options.readability = {}
   }
 
-  const dom = new JSDOM(html)
+  const vc1 = new VirtualConsole()
+  vc1.sendTo(console, { omitJSDOMErrors: true })
+  const dom = new JSDOM(html, { virtualConsole: vc1 })
 
   await setCleanRules(options.readability.cleanRulers || [])
   await prepDocument(dom.window.document)
@@ -286,7 +288,9 @@ const articleParser = async function (browser, options, socket) {
   if (options.enabled.includes('links')) {
     socket.emit('parse:status', 'Evaluating Links')
 
-    const { window } = new JSDOM(article.processed.html)
+    const vc2 = new VirtualConsole()
+    vc2.sendTo(console, { omitJSDOMErrors: true })
+    const { window } = new JSDOM(article.processed.html, { virtualConsole: vc2 })
     const $ = jquery(window)
 
     const arr = window.$('a')

--- a/test.js
+++ b/test.js
@@ -11,7 +11,7 @@ const testPlugin = function (Doc, world) {
 }
 
 const options = {
-  url: 'https://www.theguardian.com/business/2025/sep/02/uk-hit-by-fresh-sell-off-in-government-bond-markets-as-pound-weakens',
+  url: 'https://www.theguardian.com/politics/2025/sep/05/crisis-engulfs-labour-as-deputy-pm-angela-rayner-is-forced-to-step-down',
   enabled: ['lighthouse', 'screenshot', 'links', 'sentiment', 'entities', 'spelling', 'keywords', 'siteicon'],
   // Exercise spelling tweaks: include end positions and offsets
   retextspell: {


### PR DESCRIPTION
- Removes anything in square brackets: e.g., “[ ... ]”
- Removes URLs: http(s)/ftp schemes, www.*, and domain-like strings
- Keeps the previous normalization (removing alphanumeric tokens like “123abc”) and collapses whitespace
- Processes the cleaned input through retext-spell
- The “Could not parse CSS stylesheet” messages no longer appear during runs.