### PR TITLE
feat: centralize logging

### DIFF
--- a/controllers/logger.js
+++ b/controllers/logger.js
@@ -1,0 +1,21 @@
+import process from 'node:process'
+
+export function createLogger({ quiet = false } = {}) {
+  const wrap = fn => (...args) => {
+    if (quiet) return
+    try {
+      if (process?.stdout && process.stdout.writable && !process.stdout.destroyed) {
+        fn(...args)
+      }
+    } catch {}
+  }
+  return {
+    log: wrap(console.log),
+    info: wrap(console.log),
+    warn: wrap(console.warn),
+    error: wrap(console.error)
+  }
+}
+
+const defaultLogger = createLogger()
+export default defaultLogger

--- a/index.js
+++ b/index.js
@@ -18,6 +18,7 @@ import { setDefaultOptions, capitalizeFirstLetter } from './helpers.js'
 import keywordParser from './controllers/keywordParser.js'
 import lighthouseAnalysis from './controllers/lighthouse.js'
 import spellCheck from './controllers/spellCheck.js'
+import logger from './controllers/logger.js'
 
 const require = createRequire(import.meta.url)
 
@@ -31,7 +32,7 @@ const require = createRequire(import.meta.url)
  *
  */
 
-export async function parseArticle (options, socket = { emit: (type, status) => console.log(status) }) {
+export async function parseArticle (options, socket = { emit: (type, status) => logger.info(status) }) {
 
   options = setDefaultOptions(options)
   // Heuristic: bump timeout slightly for URLs that look like live pages

--- a/scripts/batch-crawl.js
+++ b/scripts/batch-crawl.js
@@ -4,6 +4,7 @@ import { parseArticle } from '../index.js'
 import blockedResourceTypes from '../scripts/inc/blockResourceTypes.js'
 import skippedResources from '../scripts/inc/skipResources.js'
 import { applyDomainTweaks, loadTweaksConfig, applyUrlRewrites } from './inc/applyDomainTweaks.js'
+import logger from '../controllers/logger.js'
 
 function makeBar(pct) {
   const w = Math.max(5, Math.min(100, Number(process.env.BATCH_BAR_WIDTH || 16)))
@@ -33,7 +34,7 @@ async function run(urlsFile, outCsv = 'candidates_with_url.csv', start = 0, limi
   let startedCount = 0
 
   if (!progressOnly) {
-    console.log(`Crawling ${urls.length} URLs (slice ${start}-${end - 1}), dumping candidates to ${outCsv}${Number(concurrency) > 1 ? ` [concurrency=${concurrency}]` : ''}`)
+    logger.info(`Crawling ${urls.length} URLs (slice ${start}-${end - 1}), dumping candidates to ${outCsv}${Number(concurrency) > 1 ? ` [concurrency=${concurrency}]` : ''}`)
   }
 
   function normalizeForCrawl(u) {
@@ -132,7 +133,7 @@ async function run(urlsFile, outCsv = 'candidates_with_url.csv', start = 0, limi
       const elapsed = Math.round((Date.now() - t0) / 1000)
       const inflight = Math.max(0, Math.min(Number(concurrency) || 1, startedCount - processed))
       const bar = makeBar(pct)
-      console.log(`[batch] ${bar} ${pct}% | ${processed}/${urls.length} done | ok:${okCount} err:${errCount} inflight:${inflight} | ${elapsed}s elapsed`)
+      logger.info(`[batch] ${bar} ${pct}% | ${processed}/${urls.length} done | ok:${okCount} err:${errCount} inflight:${inflight} | ${elapsed}s elapsed`)
       prevPct = pct
     }
   }, tickMs)
@@ -166,7 +167,7 @@ async function run(urlsFile, outCsv = 'candidates_with_url.csv', start = 0, limi
     const pct = 100
     const bar = makeBar(pct)
     const elapsed = Math.round((Date.now() - t0) / 1000)
-    console.log(`[batch] ${bar} ${pct}% | ${urls.length}/${urls.length} done | ok:${okCount} err:${errCount} inflight:0 | ${elapsed}s elapsed`)
+    logger.info(`[batch] ${bar} ${pct}% | ${urls.length}/${urls.length} done | ok:${okCount} err:${errCount} inflight:0 | ${elapsed}s elapsed`)
   } catch {}
 }
 
@@ -175,4 +176,4 @@ const outCsv = process.argv[3] || path.resolve('scripts/data/candidates_with_url
 const start = process.argv[4] || 0
 const limit = process.argv[5] || null
 const concurrency = process.argv[6] || process.env.BATCH_CONCURRENCY || 1
-run(urlsFile, outCsv, start, limit, concurrency).catch(err => { console.error(err); throw err })
+run(urlsFile, outCsv, start, limit, concurrency).catch(err => { logger.error(err); throw err })

--- a/scripts/extract-selector.js
+++ b/scripts/extract-selector.js
@@ -3,12 +3,14 @@ import StealthPlugin from 'puppeteer-extra-plugin-stealth'
 
 puppeteer.use(StealthPlugin())
 
+import logger from '../controllers/logger.js'
+
 const url = process.argv[2]
 const selectorArg = process.argv[3]
 const selector = selectorArg || 'div.post-body.entry-content, #postBody, .entry-content'
 
 if (!url) {
-  console.error('Usage: node scripts/extract-selector.js <url> [css-selector]')
+  logger.error('Usage: node scripts/extract-selector.js <url> [css-selector]')
   process.exit(1)
 }
 
@@ -70,15 +72,15 @@ if (!url) {
     }, selector)
 
     if (!info.present) {
-      console.log(`Selector not found: ${selector}`)
+      logger.info(`Selector not found: ${selector}`)
     } else {
-      console.log(`Selector found: ${selector}`)
-      console.log(`Text length: ${info.length}`)
-      console.log('--- Preview ---')
-      console.log(info.preview)
+      logger.info(`Selector found: ${selector}`)
+      logger.info(`Text length: ${info.length}`)
+      logger.info('--- Preview ---')
+      logger.info(info.preview)
     }
   } catch (err) {
-    console.error('Error:', err.message)
+    logger.error('Error:', err.message)
     process.exitCode = 1
   } finally {
     try { await browser.close() } catch {}

--- a/scripts/merge-csv.js
+++ b/scripts/merge-csv.js
@@ -1,5 +1,6 @@
 import fs from 'fs'
 import path from 'path'
+import logger from '../controllers/logger.js'
 
 function readLines(file) {
   const text = fs.readFileSync(file, 'utf8')
@@ -43,8 +44,8 @@ async function main() {
 
   const outLines = [header, ...Array.from(rows)]
   writeLines(outFile, outLines)
-  console.log(`Merged ${rows.size} unique rows into ${outFile}`)
+  logger.info(`Merged ${rows.size} unique rows into ${outFile}`)
 }
 
-main().catch(err => { console.error(err); throw err })
+main().catch(err => { logger.error(err); throw err })
 

--- a/scripts/train-reranker.js
+++ b/scripts/train-reranker.js
@@ -3,6 +3,7 @@
 // CSV columns: len,punct,ld,pc,sem,boiler,label
 
 import fs from 'fs'
+import logger from '../controllers/logger.js'
 
 function parseCsvLine(line) {
   const out = []
@@ -184,4 +185,4 @@ async function main() {
   }
 }
 
-main().catch(err => { console.error(err); throw err })
+main().catch(err => { logger.error(err); throw err })

--- a/tests/single-sample-run.js
+++ b/tests/single-sample-run.js
@@ -4,6 +4,7 @@ import path from 'path'
 import { fileURLToPath } from 'url'
 import fs from 'fs'
 import assert from 'assert'
+import logger from '../controllers/logger.js'
 
 /** add some names | https://observablehq.com/@spencermountain/compromise-plugins */
 const testPlugin = function (Doc, world) {
@@ -156,10 +157,10 @@ const __dirname = path.dirname(fileURLToPath(import.meta.url))
     const outPath = path.join(resultsDir, fileName)
 
     await fs.promises.writeFile(outPath, json, 'utf8')
-    console.log('Results written to', outPath)
+    logger.info('Results written to', outPath)
   } catch (error) {
-    console.error(error.message)
-    console.error(error.stack)
+    logger.error(error.message)
+    logger.error(error.stack)
     throw error
   }
 })()


### PR DESCRIPTION
## Summary
- add reusable logger controller with optional quiet mode
- refactor modules, scripts and tests to use the centralized logger
- remove bespoke logging helpers and direct console calls


------
https://chatgpt.com/codex/tasks/task_e_68bf12263c288332906c9f34682d6ada