### PR TITLE
Add unit tests for helpers and controllers

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "main": "index.js",
   "scripts": {
     "lint": "node ./node_modules/eslint/bin/eslint.js . --ext .json --ext .js --fix",
+    "test": "node --test",
     "merge:csv": "node scripts/merge-csv.js scripts/data/merged.csv scripts/data/candidates_with_url.csv",
     "curated:urls": "node scripts/fetch-curated-urls.js 1000",
     "batch:crawl": "node scripts/batch-crawl.js scripts/data/urls.txt scripts/data/candidates_with_url.csv",

--- a/tests/consent.test.js
+++ b/tests/consent.test.js
@@ -1,0 +1,13 @@
+import { test } from 'node:test'
+import assert from 'node:assert/strict'
+import { autoDismissConsent } from '../controllers/consent.js'
+
+test('autoDismissConsent handles empty page', async () => {
+  const page = {
+    frames: () => [],
+    waitForTimeout: async () => {},
+    waitForNavigation: async () => {},
+    keyboard: { press: async () => {} }
+  }
+  await assert.doesNotReject(() => autoDismissConsent(page))
+})

--- a/tests/contentDetector.test.js
+++ b/tests/contentDetector.test.js
@@ -1,0 +1,11 @@
+import { test } from 'node:test'
+import assert from 'node:assert/strict'
+import { JSDOM } from 'jsdom'
+import { detectContent } from '../controllers/contentDetector.js'
+
+test('detectContent extracts article HTML', () => {
+  const html = '<html><body><article><p>Hello World</p></article></body></html>'
+  const { window } = new JSDOM(html)
+  const res = detectContent(window.document)
+  assert.match(res.html, /Hello World/)
+})

--- a/tests/helpers.test.js
+++ b/tests/helpers.test.js
@@ -1,0 +1,26 @@
+import { test } from 'node:test'
+import assert from 'node:assert/strict'
+import { setDefaultOptions, capitalizeFirstLetter, toTitleCase } from '../helpers.js'
+
+test('setDefaultOptions applies defaults', () => {
+  const opts = setDefaultOptions()
+  assert.deepEqual(opts.enabled, [])
+  assert.equal(opts.timeoutMs, 10000)
+  assert.equal(opts.puppeteer.launch.headless, true)
+})
+
+test('setDefaultOptions overrides provided values', () => {
+  const opts = setDefaultOptions({ timeoutMs: 5000, puppeteer: { launch: { headless: false } } })
+  assert.equal(opts.timeoutMs, 5000)
+  assert.equal(opts.puppeteer.launch.headless, false)
+  // ensure defaults not overwritten
+  assert.equal(opts.puppeteer.launch.handleSIGINT, false)
+})
+
+test('capitalizeFirstLetter capitalizes only first character', () => {
+  assert.equal(capitalizeFirstLetter('hello'), 'Hello')
+})
+
+test('toTitleCase converts words to title case', () => {
+  assert.equal(toTitleCase('hello world'), 'Hello World')
+})

--- a/tests/keywordParser.test.js
+++ b/tests/keywordParser.test.js
@@ -1,0 +1,10 @@
+import { test } from 'node:test'
+import assert from 'node:assert/strict'
+import keywordParser from '../controllers/keywordParser.js'
+
+test('keywordParser returns keyword and keyphrase arrays', async () => {
+  const res = await keywordParser('JavaScript is great. Node.js uses JavaScript.')
+  assert.ok(Array.isArray(res.keywords))
+  assert.ok(res.keywords.length > 0)
+  assert.ok(Array.isArray(res.keyphrases))
+})

--- a/tests/lighthouse.test.js
+++ b/tests/lighthouse.test.js
@@ -1,0 +1,7 @@
+import { test } from 'node:test'
+import assert from 'node:assert/strict'
+import lighthouseAnalysis from '../controllers/lighthouse.js'
+
+test('lighthouseAnalysis is a function', () => {
+  assert.equal(typeof lighthouseAnalysis, 'function')
+})

--- a/tests/liveBlog.test.js
+++ b/tests/liveBlog.test.js
@@ -1,0 +1,20 @@
+import { test } from 'node:test'
+import assert from 'node:assert/strict'
+import { JSDOM } from 'jsdom'
+import { buildLiveBlogSummary } from '../controllers/liveBlog.js'
+
+test('buildLiveBlogSummary extracts entries from live blog', () => {
+  const html = `\n  <article>\n    <div class="update"><time>10:00 AM</time><h2>First</h2><p>${'A'.repeat(70)}</p></div>\n    <div class="update"><time>11:00 AM</time><h2>Second</h2><p>${'B'.repeat(80)}</p></div>\n    <div class="update"><time>12:00 PM</time><h2>Third</h2><p>${'C'.repeat(90)}</p></div>\n  </article>`
+  const { window } = new JSDOM(html)
+  const res = buildLiveBlogSummary(window.document)
+  assert.equal(res.ok, true)
+  assert.equal(res.count, 3)
+  assert.match(res.html, /live-summary/)
+})
+
+test('buildLiveBlogSummary returns ok false when insufficient data', () => {
+  const html = '<article><div class="update"><p>short</p></div></article>'
+  const { window } = new JSDOM(html)
+  const res = buildLiveBlogSummary(window.document)
+  assert.equal(res.ok, false)
+})

--- a/tests/logger.test.js
+++ b/tests/logger.test.js
@@ -1,0 +1,14 @@
+import { test, mock } from 'node:test'
+import assert from 'node:assert/strict'
+import { createLogger } from '../controllers/logger.js'
+
+test('createLogger respects quiet flag', () => {
+  const hook = mock.method(console, 'log', () => {})
+  const quiet = createLogger({ quiet: true })
+  quiet.log('hidden')
+  assert.equal(hook.mock.calls.length, 0)
+  const loud = createLogger()
+  loud.log('visible')
+  assert.equal(hook.mock.calls.length, 1)
+  hook.mock.restore()
+})

--- a/tests/spellCheck.test.js
+++ b/tests/spellCheck.test.js
@@ -1,0 +1,9 @@
+import { test } from 'node:test'
+import assert from 'node:assert/strict'
+import spellCheck from '../controllers/spellCheck.js'
+
+test('spellCheck identifies misspellings', async () => {
+  const res = await spellCheck('This sentense has a mispelled wurd.')
+  assert.ok(Array.isArray(res))
+  assert.ok(res.length > 0)
+})

--- a/tests/structuredData.test.js
+++ b/tests/structuredData.test.js
@@ -1,0 +1,12 @@
+import { test } from 'node:test'
+import assert from 'node:assert/strict'
+import { JSDOM } from 'jsdom'
+import { extractStructuredData } from '../controllers/structuredData.js'
+
+test('extractStructuredData reads headline and body from JSON-LD', () => {
+  const script = `<script type="application/ld+json">{"@type":"NewsArticle","headline":"Hello","articleBody":"World"}</script>`
+  const { window } = new JSDOM(`<html><body>${script}</body></html>`)
+  const res = extractStructuredData(window.document)
+  assert.equal(res.headline, 'Hello')
+  assert.equal(res.articleBody, 'World')
+})

--- a/tests/textProcessing.test.js
+++ b/tests/textProcessing.test.js
@@ -1,0 +1,26 @@
+import { test } from 'node:test'
+import assert from 'node:assert/strict'
+import { getRawText, getFormattedText, getHtmlText, htmlCleaner } from '../controllers/textProcessing.js'
+
+test('getRawText strips URLs', () => {
+  const html = '<p>Visit <a href="http://example.com">http://example.com</a></p>'
+  const text = getRawText(html)
+  assert.equal(text.includes('http'), false)
+})
+
+test('getFormattedText adds title and uppercases headings', () => {
+  const html = '<p>content</p>'
+  const text = getFormattedText(html, 'Title', 'http://example.com')
+  assert.match(text, /^TITLE\n\ncontent/)
+})
+
+test('getHtmlText wraps lines with spans', () => {
+  const res = getHtmlText('line1\nline2')
+  assert.equal(res.split('\n')[0], '<span>line1</span>')
+})
+
+test('htmlCleaner resolves with sanitized html', async () => {
+  const out = await htmlCleaner('&nbsp;<span>hi</span>')
+  assert.equal(typeof out, 'string')
+  assert.ok(out.includes('hi'))
+})

--- a/tests/titleDetector.test.js
+++ b/tests/titleDetector.test.js
@@ -1,0 +1,16 @@
+import { test } from 'node:test'
+import assert from 'node:assert/strict'
+import { JSDOM } from 'jsdom'
+import { detectTitle } from '../controllers/titleDetector.js'
+
+test('detectTitle prefers og:title meta', () => {
+  const html = `<head><meta property="og:title" content="OG"><title>Doc</title></head><body><h1>Heading</h1></body>`
+  const { window } = new JSDOM(html)
+  assert.equal(detectTitle(window.document), 'OG')
+})
+
+test('detectTitle falls back to h1 and strips suffix', () => {
+  const html = `<head><title>Heading - Site</title></head><body><h1>Heading - Site</h1></body>`
+  const { window } = new JSDOM(html)
+  assert.equal(detectTitle(window.document), 'Heading')
+})


### PR DESCRIPTION
## Summary
- add npm test script using Node's built-in test runner
- cover helper utilities, live blog summary extraction, and every controller with unit tests

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bf3cbad4748332ba622557c5873fe7