### PR TITLE
Silence parser logs during tests

### DIFF
--- a/tests/parseArticle.test.js
+++ b/tests/parseArticle.test.js
@@ -4,6 +4,9 @@ import fs from 'fs'
 import http from 'node:http'
 import { parseArticle } from '../index.js'
 
+// Silent socket to suppress parser status logs during tests
+const quietSocket = { emit: () => {} }
+
 test('parseArticle processes local HTML', async (t) => {
   const html = fs.readFileSync('tests/fixtures/integration/sample.html', 'utf8')
   const dataUrl = 'data:text/html;base64,' + Buffer.from(html).toString('base64')
@@ -12,7 +15,7 @@ test('parseArticle processes local HTML', async (t) => {
       url: dataUrl,
       enabled: ['spelling'],
       puppeteer: { launch: { headless: true, args: ['--no-sandbox', '--disable-setuid-sandbox'] } }
-    })
+    }, quietSocket)
     assert.equal(article.title.text, 'Sample Story')
     assert.ok(article.links.some(l => /example\.com/.test(l.href)))
     assert.ok(article.spelling.some(s => s.word.toLowerCase().includes('missspelled')))
@@ -34,7 +37,7 @@ test('parseArticle uses rules overrides for title and content', async (t) => {
     const baseline = await parseArticle({
       url,
       puppeteer: { launch: { headless: true, args: ['--no-sandbox', '--disable-setuid-sandbox'] } }
-    })
+    }, quietSocket)
     assert.equal(baseline.title.text, 'Wrong')
     assert.equal(baseline.processed.text.raw.trim(), 'Incorrect')
 
@@ -46,7 +49,7 @@ test('parseArticle uses rules overrides for title and content', async (t) => {
         content: () => '<article><p>Correct</p></article>'
       }],
       puppeteer: { launch: { headless: true, args: ['--no-sandbox', '--disable-setuid-sandbox'] } }
-    })
+    }, quietSocket)
     assert.equal(article.title.text, 'Right')
     assert.equal(article.processed.text.raw.trim(), 'Correct')
   } catch (err) {
@@ -64,7 +67,7 @@ test('parseArticle respects timeoutMs option', async (t) => {
       url: dataUrl,
       timeoutMs: 1,
       puppeteer: { launch: { headless: true, args: ['--no-sandbox', '--disable-setuid-sandbox'] } }
-    })
+    }, quietSocket)
     t.fail('Expected parse to timeout')
   } catch (err) {
     if (/Timeout/i.test(err.message)) {
@@ -82,13 +85,13 @@ test('parseArticle can disable JavaScript execution', async (t) => {
     const withJs = await parseArticle({
       url: dataUrl,
       puppeteer: { launch: { headless: true, args: ['--no-sandbox', '--disable-setuid-sandbox'] } }
-    })
+    }, quietSocket)
     assert.equal(withJs.title.text, 'Changed')
 
     const withoutJs = await parseArticle({
       url: dataUrl,
       puppeteer: { launch: { headless: true, args: ['--no-sandbox', '--disable-setuid-sandbox'], javascriptEnabled: false } }
-    })
+    }, quietSocket)
     assert.equal(withoutJs.title.text, 'Original')
   } catch (err) {
     t.skip('puppeteer unavailable: ' + err.message)
@@ -103,7 +106,7 @@ test('parseArticle strips selectors listed in striptags', async (t) => {
       url: dataUrl,
       striptags: ['.ad', '#remove-me'],
       puppeteer: { launch: { headless: true, args: ['--no-sandbox', '--disable-setuid-sandbox'] } }
-    })
+    }, quietSocket)
     assert.equal(article.title.text, 'StripTags Test')
     assert.equal(article.processed.text.raw.trim(), 'Keep me')
   } catch (err) {
@@ -128,7 +131,7 @@ test('parseArticle applies custom Compromise plugins', async (t) => {
       url: dataUrl,
       enabled: ['entities'],
       puppeteer: { launch: { headless: true, args: ['--no-sandbox', '--disable-setuid-sandbox'] } }
-    })
+    }, quietSocket)
     const foundWithout = Array.isArray(withoutPlugin.people) && withoutPlugin.people.some(p => /rishi/i.test(p.text))
     assert.equal(foundWithout, false)
 
@@ -137,7 +140,7 @@ test('parseArticle applies custom Compromise plugins', async (t) => {
       enabled: ['entities'],
       nlp: { plugins: [testPlugin] },
       puppeteer: { launch: { headless: true, args: ['--no-sandbox', '--disable-setuid-sandbox'] } }
-    })
+    }, quietSocket)
     const foundWith = Array.isArray(withPlugin.people) && withPlugin.people.some(p => /rishi sunak/i.test(p.text))
     assert.equal(foundWith, true)
   } catch (err) {


### PR DESCRIPTION
## Summary
- Prevent parser status logs from cluttering test output by using a silent socket in parseArticle tests

## Testing
- `NODE_ENV=test node --test`


------
https://chatgpt.com/codex/tasks/task_e_68bf5b7e24288332b0801935341aa6e1