### PR TITLE
Expand script test coverage

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,7 @@
+# AGENTS
+
+- Install Google Chrome and its required system libraries (e.g. `fonts-liberation`, `libasound2`, `libatk-bridge2.0-0`, `libgtk-3-0`, `libnss3`, `libx11-xcb1`, `libxkbcommon0`, `libu2f-udev`) then verify it immediately with:
+  - `google-chrome --version`
+- Install Node.js dependencies and confirm `cross-env` is present:
+  - `npm install`
+  - `npm list cross-env`

--- a/scripts/batch-crawl.js
+++ b/scripts/batch-crawl.js
@@ -6,20 +6,20 @@ import skippedResources from '../scripts/inc/skipResources.js'
 import { applyDomainTweaks, loadTweaksConfig, applyUrlRewrites } from './inc/applyDomainTweaks.js'
 import logger from '../controllers/logger.js'
 
-function makeBar(pct) {
+export function makeBar(pct) {
   const w = Math.max(5, Math.min(100, Number(process.env.BATCH_BAR_WIDTH || 16)))
   const filled = Math.max(0, Math.min(w, Math.round((pct / 100) * w)))
   const empty = w - filled
   return `[${'#'.repeat(filled)}${'.'.repeat(empty)}]`
 }
 
-function readUrls(filePath) {
+export function readUrls(filePath) {
   if (!fs.existsSync(filePath)) throw new Error(`URLs file not found: ${filePath}`)
   const text = fs.readFileSync(filePath, 'utf8')
   return text.split(/\r?\n/).map(s => s.trim()).filter(Boolean)
 }
 
-async function run(urlsFile, outCsv = 'candidates_with_url.csv', start = 0, limit = null, concurrency = 1) {
+export async function run(urlsFile, outCsv = 'candidates_with_url.csv', start = 0, limit = null, concurrency = 1) {
   const all = readUrls(urlsFile)
   const end = limit ? Math.min(all.length, start + Number(limit)) : all.length
   const urls = all.slice(Number(start) || 0, end)
@@ -171,9 +171,11 @@ async function run(urlsFile, outCsv = 'candidates_with_url.csv', start = 0, limi
   } catch {}
 }
 
-const urlsFile = process.argv[2] || path.resolve('scripts/data/urls.txt')
-const outCsv = process.argv[3] || path.resolve('scripts/data/candidates_with_url.csv')
-const start = process.argv[4] || 0
-const limit = process.argv[5] || null
-const concurrency = process.argv[6] || process.env.BATCH_CONCURRENCY || 1
-run(urlsFile, outCsv, start, limit, concurrency).catch(err => { logger.error(err); throw err })
+if (import.meta.url === `file://${process.argv[1]}`) {
+  const urlsFile = process.argv[2] || path.resolve('scripts/data/urls.txt')
+  const outCsv = process.argv[3] || path.resolve('scripts/data/candidates_with_url.csv')
+  const start = process.argv[4] || 0
+  const limit = process.argv[5] || null
+  const concurrency = process.argv[6] || process.env.BATCH_CONCURRENCY || 1
+  run(urlsFile, outCsv, start, limit, concurrency).catch(err => { logger.error(err); throw err })
+}

--- a/scripts/merge-csv.js
+++ b/scripts/merge-csv.js
@@ -2,23 +2,16 @@ import fs from 'fs'
 import path from 'path'
 import logger from '../controllers/logger.js'
 
-function readLines(file) {
+export function readLines(file) {
   const text = fs.readFileSync(file, 'utf8')
   return text.split(/\r?\n/)
 }
 
-function writeLines(file, lines) {
+export function writeLines(file, lines) {
   fs.writeFileSync(file, lines.join('\n') + '\n', 'utf8')
 }
 
-async function main() {
-  const args = process.argv.slice(2)
-  if (args.length < 2) {
-    throw new Error('Usage: node scripts/merge-csv.js output.csv input1.csv [input2.csv ...]')
-  }
-  const outFile = args[0]
-  const inFiles = args.slice(1)
-
+export function mergeCsv(outFile, inFiles) {
   let header = null
   const rows = new Set()
 
@@ -47,5 +40,18 @@ async function main() {
   logger.info(`Merged ${rows.size} unique rows into ${outFile}`)
 }
 
-main().catch(err => { logger.error(err); throw err })
+async function main() {
+  const args = process.argv.slice(2)
+  if (args.length < 2) {
+    throw new Error('Usage: node scripts/merge-csv.js output.csv input1.csv [input2.csv ...]')
+  }
+  const outFile = args[0]
+  const inFiles = args.slice(1)
+
+  mergeCsv(outFile, inFiles)
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  main().catch(err => { logger.error(err); throw err })
+}
 

--- a/scripts/train-reranker.js
+++ b/scripts/train-reranker.js
@@ -5,7 +5,7 @@
 import fs from 'fs'
 import logger from '../controllers/logger.js'
 
-function parseCsvLine(line) {
+export function parseCsvLine(line) {
   const out = []
   let cur = ''
   let inQuotes = false
@@ -25,7 +25,7 @@ function parseCsvLine(line) {
   return out
 }
 
-function indexMap(headers, names) {
+export function indexMap(headers, names) {
   const map = {}
   for (const [key, aliases] of Object.entries(names)) {
     let idx = -1
@@ -38,7 +38,7 @@ function indexMap(headers, names) {
   return map
 }
 
-function parseCSV(text) {
+export function parseCSV(text) {
   const lines = text.split(/\r?\n/).filter(Boolean)
   const rows = []
   let headers = null
@@ -139,9 +139,9 @@ function parseCSV(text) {
   return rows
 }
 
-function sigmoid(z) { return 1 / (1 + Math.exp(-z)) }
+export function sigmoid(z) { return 1 / (1 + Math.exp(-z)) }
 
-function train(data, { lr = 0.05, epochs = 250, l2 = 0.001 } = {}) {
+export function train(data, { lr = 0.05, epochs = 250, l2 = 0.001 } = {}) {
   if (!data.length) return { weights: [], bias: 0 }
   const d = data[0].x.length
   let w = new Array(d).fill(0)
@@ -185,4 +185,6 @@ async function main() {
   }
 }
 
-main().catch(err => { logger.error(err); throw err })
+if (import.meta.url === `file://${process.argv[1]}`) {
+  main().catch(err => { logger.error(err); throw err })
+}

--- a/tests/batchCrawl.test.js
+++ b/tests/batchCrawl.test.js
@@ -1,0 +1,19 @@
+import { test } from 'node:test'
+import assert from 'node:assert/strict'
+import fs from 'fs'
+import path from 'path'
+import os from 'os'
+import { makeBar, readUrls } from '../scripts/batch-crawl.js'
+
+test('makeBar respects width env', () => {
+  process.env.BATCH_BAR_WIDTH = '10'
+  assert.equal(makeBar(50), '[#####.....]')
+})
+
+test('readUrls trims and filters lines', () => {
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'urls-'))
+  const file = path.join(tmpDir, 'u.txt')
+  fs.writeFileSync(file, 'http://a.com\n\nhttp://b.com\n')
+  const urls = readUrls(file)
+  assert.deepEqual(urls, ['http://a.com', 'http://b.com'])
+})

--- a/tests/batchSampleRun.test.js
+++ b/tests/batchSampleRun.test.js
@@ -1,0 +1,39 @@
+import { test } from 'node:test'
+import assert from 'node:assert/strict'
+import { ampCandidates, skipUrl, uniqueByHost, buildOptions, classifyError } from '../scripts/batch-sample-run.js'
+
+test('ampCandidates generates variants', () => {
+  const res = ampCandidates('https://example.com/news/story')
+  assert.deepEqual(res, [
+    'https://example.com/news/story/amp',
+    'https://example.com/news/story/amp.html',
+    'https://example.com/news/story?amp=1',
+    'https://example.com/news/story?output=amp'
+  ])
+})
+
+test('skipUrl identifies non-html resources', () => {
+  assert.equal(skipUrl('ftp://example.com/file'), 'skip: non-http(s) scheme')
+  assert.equal(skipUrl('https://example.com/file.pdf'), 'skip: non-html resource')
+  assert.equal(skipUrl('https://example.com/article'), null)
+})
+
+test('uniqueByHost keeps first url per host', () => {
+  const list = ['https://a.com/1', 'https://b.com/1', 'https://a.com/2']
+  assert.deepEqual(uniqueByHost(list, 5), ['https://a.com/1', 'https://b.com/1'])
+})
+
+test('buildOptions sets defaults', () => {
+  const opts = buildOptions('https://example.com', 1000)
+  assert.equal(opts.url, 'https://example.com')
+  assert.equal(opts.timeoutMs, 1000)
+  assert.deepEqual(opts.blockedResourceTypes, ['media','font','stylesheet'])
+})
+
+test('classifyError groups messages', () => {
+  assert.equal(classifyError('Timeout exceeded'), 'timeout')
+  assert.equal(classifyError('403 Forbidden'), 'forbidden')
+  assert.equal(classifyError('cookie consent needed'), 'consent')
+  assert.equal(classifyError('Execution context destroyed'), 'context')
+  assert.equal(classifyError('misc'), 'generic')
+})

--- a/tests/fetchCuratedUrls.test.js
+++ b/tests/fetchCuratedUrls.test.js
@@ -1,0 +1,34 @@
+import { test } from 'node:test'
+import assert from 'node:assert/strict'
+import fs from 'fs'
+import path from 'path'
+import os from 'os'
+import { readFeedsFile, keepLikelyArticles, extractFromRSS, extractFromSitemap, makeBar } from '../scripts/fetch-curated-urls.js'
+
+test('readFeedsFile ignores comments and blanks', () => {
+  const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'feeds-'))
+  const file = path.join(tmp, 'feeds.txt')
+  fs.writeFileSync(file, '# comment\n\nhttp://a.com/rss\n https://b.com/feed\n')
+  const feeds = readFeedsFile(file)
+  assert.deepEqual(feeds, ['http://a.com/rss', 'https://b.com/feed'])
+})
+
+test('keepLikelyArticles filters non-articles', () => {
+  assert.equal(keepLikelyArticles('https://example.com/2020/05/foo-bar'), true)
+  assert.equal(keepLikelyArticles('https://example.com'), false)
+})
+
+test('extractFromRSS returns item links', () => {
+  const xml = '<rss><channel><item><link>http://example.com/a</link></item></channel></rss>'
+  assert.deepEqual(extractFromRSS(xml), ['http://example.com/a'])
+})
+
+test('extractFromSitemap returns loc entries', () => {
+  const xml = '<urlset><url><loc>http://example.com/a</loc></url><url><loc>http://example.com/b</loc></url></urlset>'
+  assert.deepEqual(extractFromSitemap(xml), ['http://example.com/a', 'http://example.com/b'])
+})
+
+test('makeBar respects width env', () => {
+  process.env.FEED_BAR_WIDTH = '10'
+  assert.equal(makeBar(30), '[###.......]')
+})

--- a/tests/mergeCsv.test.js
+++ b/tests/mergeCsv.test.js
@@ -1,0 +1,23 @@
+import { test } from 'node:test'
+import assert from 'node:assert/strict'
+import fs from 'fs'
+import os from 'os'
+import path from 'path'
+import { mergeCsv } from '../scripts/merge-csv.js'
+
+test('mergeCsv merges unique rows across files', () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'merge-csv-'))
+  const outFile = path.join(dir, 'out.csv')
+  const input1 = path.join(dir, 'in1.csv')
+  const input2 = path.join(dir, 'in2.csv')
+
+  fs.writeFileSync(input1, 'header\nrow1\nrow2\n')
+  fs.writeFileSync(input2, 'header\nrow2\nrow3\n')
+
+  mergeCsv(outFile, [input1, input2])
+
+  const result = fs.readFileSync(outFile, 'utf8').trim().split(/\r?\n/)
+  assert.deepEqual(result, ['header', 'row1', 'row2', 'row3'])
+
+  fs.rmSync(dir, { recursive: true, force: true })
+})

--- a/tests/trainReranker.test.js
+++ b/tests/trainReranker.test.js
@@ -1,0 +1,25 @@
+import { test } from 'node:test'
+import assert from 'node:assert/strict'
+import { parseCsvLine, parseCSV, train } from '../scripts/train-reranker.js'
+
+test('parseCsvLine handles quoted commas', () => {
+  const fields = parseCsvLine('a,"b,c",d')
+  assert.deepEqual(fields, ['a', 'b,c', 'd'])
+})
+
+test('parseCSV builds rows with vectors', () => {
+  const csv = `text_length,punctuation_count,link_density,paragraph_count,has_semantic_container,boilerplate_penalty,direct_paragraph_count,direct_block_count,paragraph_to_block_ratio,average_paragraph_length,dom_depth,heading_children_count,aria_role_main,aria_role_negative,aria_hidden,image_alt_ratio,image_count,training_label\n` +
+    `10,5,0.1,2,1,0.5,1,1,0.5,100,3,0,1,0,0,0.2,1,1\n` +
+    `20,8,0.2,4,0,0.1,2,2,1,150,5,1,0,0,0,0.3,0,0\n`
+  const rows = parseCSV(csv)
+  assert.equal(rows.length, 2)
+  assert.equal(rows[0].x.length, 16)
+  assert.equal(rows[1].y, 0)
+})
+
+test('train returns weights and bias', () => {
+  const data = [{ x: [0,0], y: 0 }, { x: [1,1], y: 1 }]
+  const model = train(data, { epochs: 10, lr: 0.1 })
+  assert.equal(model.weights.length, 2)
+  assert.equal(typeof model.bias, 'number')
+})


### PR DESCRIPTION
## Summary
- expose helpers from batch-crawl, batch-sample-run, fetch-curated-urls, and train-reranker for direct unit testing
- add unit tests covering progress bars, URL filtering, AMP variants, feed parsing, and CSV trainer logic
- document environment setup requirements in AGENTS.md

## Testing
- `google-chrome --version`
- `npm install --no-audit --no-fund`
- `npm list cross-env`
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bf6382f5e08332b6e9aee58096d5bc