### PR TITLE
Add proxy support to curated URL fetcher

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "horseman-article-parser",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "horseman-article-parser",
-      "version": "1.0.0",
+      "version": "1.1.0",
       "license": "GPL-3.0",
       "dependencies": {
         "absolutify": "^0.1.0",
@@ -28,7 +28,8 @@
         "retext-keywords": "^8.0.2",
         "retext-pos": "^5.0.0",
         "retext-spell": "^6.1.0",
-        "sentiment": "^5.0.1"
+        "sentiment": "^5.0.1",
+        "undici": "^7.15.0"
       },
       "devDependencies": {
         "@eslint/eslintrc": "^3.3.1",
@@ -7490,6 +7491,15 @@
       "integrity": "sha512-GMXzWtsc57XAtguZgaQViUOzs0KTkk8ojr3/xAxXLITqf/3EMwxC0inyETfDFjH/Krbhuep0HNbbjI9i/q3F3g==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/undici": {
+      "version": "7.15.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.15.0.tgz",
+      "integrity": "sha512-7oZJCPvvMvTd0OlqWsIxTuItTpJBpU1tcbVl24FMn3xt3+VSunwUasmfPJRE57oNO1KsZ4PgA1xTdAX4hq8NyQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.18.1"
+      }
     },
     "node_modules/undici-types": {
       "version": "7.10.0",

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "lighthouse": "^12.8.2",
     "lodash": "^4.17.21",
     "nlcst-to-string": "^4.0.0",
+    "undici": "^7.15.0",
     "puppeteer": "^24.18.0",
     "puppeteer-extra": "^3.3.6",
     "puppeteer-extra-plugin-stealth": "^2.11.2",

--- a/scripts/fetch-curated-urls.js
+++ b/scripts/fetch-curated-urls.js
@@ -2,7 +2,18 @@
 import fs from 'fs'
 import path from 'path'
 import { XMLParser } from 'fast-xml-parser'
+import { ProxyAgent, setGlobalDispatcher } from 'undici'
 import logger, { createLogger } from '../controllers/logger.js'
+
+// Enable proxy support when HTTP(S)_PROXY env vars are present
+const proxy =
+  process.env.HTTPS_PROXY ||
+  process.env.https_proxy ||
+  process.env.HTTP_PROXY ||
+  process.env.http_proxy
+if (proxy) {
+  try { setGlobalDispatcher(new ProxyAgent(proxy)) } catch {}
+}
 
 // Reads newline-delimited feed URLs from a text file.
 // - ignores blank lines and lines starting with '#'


### PR DESCRIPTION
## Summary
- use `undici` ProxyAgent to respect HTTP(S)_PROXY variables in `fetch-curated-urls.js`
- add `undici` dependency

## Testing
- `google-chrome --version`
- `npm list cross-env`
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bf729d9d5883329696864f1f9a8f30