### PR TITLE
fix: enable fetch script on windows

### DIFF
--- a/scripts/batch-crawl.js
+++ b/scripts/batch-crawl.js
@@ -5,6 +5,7 @@ import blockedResourceTypes from '../scripts/inc/blockResourceTypes.js'
 import skippedResources from '../scripts/inc/skipResources.js'
 import { applyDomainTweaks, loadTweaksConfig, applyUrlRewrites } from './inc/applyDomainTweaks.js'
 import logger from '../controllers/logger.js'
+import { fileURLToPath } from 'url'
 
 export function makeBar(pct) {
   const w = Math.max(5, Math.min(100, Number(process.env.BATCH_BAR_WIDTH || 16)))
@@ -171,7 +172,9 @@ export async function run(urlsFile, outCsv = 'candidates_with_url.csv', start = 
   } catch {}
 }
 
-if (import.meta.url === `file://${process.argv[1]}`) {
+const isCli =
+  process.argv[1] && fileURLToPath(import.meta.url) === path.resolve(process.argv[1])
+if (isCli) {
   const urlsFile = process.argv[2] || path.resolve('scripts/data/urls.txt')
   const outCsv = process.argv[3] || path.resolve('scripts/data/candidates_with_url.csv')
   const start = process.argv[4] || 0

--- a/scripts/batch-sample-run.js
+++ b/scripts/batch-sample-run.js
@@ -3,6 +3,7 @@ import path from 'path'
 import { parseArticle } from '../index.js'
 import { applyDomainTweaks, loadTweaksConfig, applyUrlRewrites } from './inc/applyDomainTweaks.js'
 import logger from '../controllers/logger.js'
+import { fileURLToPath } from 'url'
 
 // Lightweight HTTP helpers using global fetch (Node >=18)
 export function defaultHeaders(u) {
@@ -383,6 +384,8 @@ async function main() {
   logger.info(`[sample] wrote host breakdown to ${hostCsv}`)
 }
 
-if (import.meta.url === `file://${process.argv[1]}`) {
+const isCli =
+  process.argv[1] && fileURLToPath(import.meta.url) === path.resolve(process.argv[1])
+if (isCli) {
   main().catch(err => { logger.error(err); process.exit(1) })
 }

--- a/scripts/fetch-curated-urls.js
+++ b/scripts/fetch-curated-urls.js
@@ -4,6 +4,7 @@ import path from 'path'
 import { XMLParser } from 'fast-xml-parser'
 import { ProxyAgent, setGlobalDispatcher } from 'undici'
 import logger, { createLogger } from '../controllers/logger.js'
+import { fileURLToPath } from 'url'
 
 // Enable proxy support when HTTP(S)_PROXY env vars are present
 const proxy =
@@ -286,6 +287,11 @@ async function main() {
   logger.info(`Wrote ${urls.length} curated URLs to ${outFile}`)
 }
 
-if (import.meta.url === `file://${process.argv[1]}`) {
-  main().catch(err => { logger.error(err); throw err })
+const isCli =
+  process.argv[1] && fileURLToPath(import.meta.url) === path.resolve(process.argv[1])
+if (isCli) {
+  main().catch(err => {
+    logger.error(err)
+    throw err
+  })
 }


### PR DESCRIPTION
## Summary
- ensure fetch-curated-urls CLI starts on Windows by comparing paths via fileURLToPath
- ensure batch-crawl CLI starts on Windows using same path normalization
- ensure batch-sample-run CLI starts on Windows via normalized path check

## Testing
- `google-chrome --version`
- `npm install`
- `npm list cross-env`
- `npm test`
- `node scripts/fetch-curated-urls.js 5`
- `node scripts/batch-crawl.js scripts/data/urls.txt scripts/data/out.csv 0 1`
- `node scripts/batch-sample-run.js 1 1 scripts/data/urls.txt 5000`


------
https://chatgpt.com/codex/tasks/task_e_68bfe4818710833298793fd053399b1f