### PR TITLE
feat: clarify CLI arguments with named flags

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,10 +8,10 @@
     "lint": "node ./node_modules/eslint/bin/eslint.js . --ext .json --ext .js --fix",
     "test": "cross-env NODE_ENV=test node --test",
     "merge:csv": "node scripts/merge-csv.js scripts/data/merged.csv scripts/data/candidates_with_url.csv",
-    "sample:prepare": "cross-env PROGRESS_ONLY=1 node scripts/fetch-curated-urls.js 200",
+    "sample:prepare": "cross-env PROGRESS_ONLY=1 node scripts/fetch-curated-urls.js --count 200",
     "sample:single": "node scripts/single-sample-run.js",
-    "sample:batch": "cross-env PROGRESS_ONLY=1 node scripts/batch-sample-run.js 100 5 scripts/data/urls.txt 20000",
-    "batch:crawl": "cross-env PROGRESS_ONLY=1 node scripts/batch-crawl.js scripts/data/urls.txt scripts/data/candidates_with_url.csv",
+    "sample:batch": "cross-env PROGRESS_ONLY=1 node scripts/batch-sample-run.js --count 100 --concurrency 5 --urls-file scripts/data/urls.txt --timeout 20000",
+    "batch:crawl": "cross-env PROGRESS_ONLY=1 node scripts/batch-crawl.js --urls-file scripts/data/urls.txt --out-file scripts/data/candidates_with_url.csv",
     "train:ranker": "node scripts/train-reranker.js",
     "docs": "jsdoc2md index.js controllers/*.js helpers.js > APIDOC.md"
   },

--- a/scripts/fetch-curated-urls.js
+++ b/scripts/fetch-curated-urls.js
@@ -5,6 +5,7 @@ import { XMLParser } from 'fast-xml-parser'
 import { ProxyAgent, setGlobalDispatcher } from 'undici'
 import logger, { createLogger } from '../controllers/logger.js'
 import { fileURLToPath } from 'url'
+import { parseArgs } from 'node:util'
 
 // Enable proxy support when HTTP(S)_PROXY env vars are present
 const proxy =
@@ -178,7 +179,7 @@ export function extractFromSitemap(xml) {
 }
 
 export function makeBar(pct) {
-  const w = Math.max(5, Math.min(100, Number(process.env.FEED_BAR_WIDTH || 16)))
+  const w = Math.max(5, Math.min(100, Number(process.env.PROGRESS_BAR_WIDTH || 16)))
   const filled = Math.max(0, Math.min(w, Math.round((pct / 100) * w)))
   const empty = w - filled
   return `[${'#'.repeat(filled)}${'.'.repeat(empty)}]`
@@ -273,8 +274,14 @@ export async function collect(count, feeds) {
 }
 
 async function main() {
-  const target = Number(process.argv[2] || 1000)
-  const feedsPath = process.argv[3] || process.env.FEEDS_FILE || path.resolve('scripts/data/feeds.txt')
+  const { values } = parseArgs({
+    options: {
+      count: { type: 'string', default: '1000' },
+      'feeds-file': { type: 'string', default: process.env.FEEDS_FILE || path.resolve('scripts/data/feeds.txt') }
+    }
+  })
+  const target = Number(values.count)
+  const feedsPath = values['feeds-file']
   const feeds = readFeedsFile(feedsPath)
   const urls = await collect(target, feeds)
   if (urls.length < target) {

--- a/scripts/single-sample-run.js
+++ b/scripts/single-sample-run.js
@@ -5,6 +5,7 @@ import { fileURLToPath } from 'url'
 import fs from 'fs'
 import assert from 'assert'
 import logger from '../controllers/logger.js'
+import { parseArgs } from 'node:util'
 
 /** add some names | https://observablehq.com/@spencermountain/compromise-plugins */
 const testPlugin = function (Doc, world) {
@@ -14,9 +15,10 @@ const testPlugin = function (Doc, world) {
   })
 }
 
-// Allow passing a URL via CLI: `node scripts/single-sample-run.js <url>`
-// With npm: `npm run test -- <url>`
-const inputUrl = process.argv[2] || null
+// Allow passing a URL via CLI: `node scripts/single-sample-run.js --url <url>`
+// With npm: `npm run sample:single -- --url <url>`
+const { values } = parseArgs({ options: { url: { type: 'string' } } })
+const inputUrl = values.url || null
 
 const options = {
   timeoutMs: Number(process.env.TEST_TIMEOUT_MS || 40000),

--- a/tests/batchCrawl.test.js
+++ b/tests/batchCrawl.test.js
@@ -6,7 +6,7 @@ import os from 'os'
 import { makeBar, readUrls } from '../scripts/batch-crawl.js'
 
 test('makeBar respects width env', () => {
-  process.env.BATCH_BAR_WIDTH = '10'
+  process.env.PROGRESS_BAR_WIDTH = '10'
   assert.equal(makeBar(50), '[#####.....]')
 })
 

--- a/tests/fetchCuratedUrls.test.js
+++ b/tests/fetchCuratedUrls.test.js
@@ -29,6 +29,6 @@ test('extractFromSitemap returns loc entries', () => {
 })
 
 test('makeBar respects width env', () => {
-  process.env.FEED_BAR_WIDTH = '10'
+  process.env.PROGRESS_BAR_WIDTH = '10'
   assert.equal(makeBar(30), '[###.......]')
 })


### PR DESCRIPTION
## Summary
- switch scripts to use named CLI flags via `parseArgs`
- unify progress bar width env var as `PROGRESS_BAR_WIDTH`
- document and wire npm scripts with explicit `--` argument forwarding

## Testing
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c025a03c08833284a724513286adce