### PR TITLE
feat: pass timeout as argument in single URL sample

### DIFF
--- a/README.md
+++ b/README.md
@@ -371,14 +371,14 @@ Run quick tests and batches from this repo without writing code.
 Writes a detailed JSON to `scripts/results/single-sample-run-result.json`.
 
 ```bash
-npx cross-env TEST_TIMEOUT_MS=40000 node scripts/single-sample-run.js --url "https://www.cnn.com/business/live-news/fox-news-dominion-trial-04-18-23/index.html"
+node scripts/single-sample-run.js --url "https://www.cnn.com/business/live-news/fox-news-dominion-trial-04-18-23/index.html" --timeout 40000
 # or via npm script
-npm run sample:single -- --url "https://www.cnn.com/business/live-news/fox-news-dominion-trial-04-18-23/index.html"
+npm run sample:single -- --url "https://www.cnn.com/business/live-news/fox-news-dominion-trial-04-18-23/index.html" --timeout 40000
 ```
 
 Parameters
 
-- `TEST_TIMEOUT_MS`: maximum time (ms) for the parse. If omitted, the test uses its default.
+- `--timeout`: maximum time (ms) for the parse. If omitted, the test uses its default (40000 ms).
 - `--url`: the article page to parse.
 
 ### Batch sampler (curated URLs, progress bar)

--- a/scripts/single-sample-run.js
+++ b/scripts/single-sample-run.js
@@ -15,13 +15,14 @@ const testPlugin = function (Doc, world) {
   })
 }
 
-// Allow passing a URL via CLI: `node scripts/single-sample-run.js --url <url>`
-// With npm: `npm run sample:single -- --url <url>`
-const { values } = parseArgs({ options: { url: { type: 'string' } } })
+// Allow passing a URL via CLI: `node scripts/single-sample-run.js --url <url> --timeout <ms>`
+// With npm: `npm run sample:single -- --url <url> --timeout <ms>`
+const { values } = parseArgs({ options: { url: { type: 'string' }, timeout: { type: 'string' } } })
 const inputUrl = values.url || null
+const timeoutMs = Number(values.timeout || 40000)
 
 const options = {
-  timeoutMs: Number(process.env.TEST_TIMEOUT_MS || 40000),
+  timeoutMs,
   url: inputUrl || 'https://www.bbc.co.uk/news/articles/cnvryg271ymo?at_medium=RSS&at_campaign=rss',
   enabled: ['links', 'sentiment', 'entities', 'spelling', 'keywords', 'siteicon'],
   // In tests, lightly block heavy resources (keep images)


### PR DESCRIPTION
## Summary
- document passing url and timeout arguments for single URL sample
- accept `--timeout` CLI argument in single-sample-run script

## Testing
- `google-chrome --version`
- `npm list cross-env`
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c03ae421108332908833c7cb458fce