### PR TITLE
fix test script for cross-platform compatibility

### DIFF
--- a/controllers/logger.js
+++ b/controllers/logger.js
@@ -17,5 +17,5 @@ export function createLogger({ quiet = false } = {}) {
   }
 }
 
-const defaultLogger = createLogger({ quiet: process.env.NODE_ENV === 'test' })
+const defaultLogger = createLogger({ quiet: process.execArgv.includes('--test') })
 export default defaultLogger

--- a/index.js
+++ b/index.js
@@ -1,7 +1,8 @@
 import puppeteer from 'puppeteer-extra'
 import StealthPlugin from 'puppeteer-extra-plugin-stealth'
 
-if (process.env.NODE_ENV !== 'test') {
+const isTestRun = process.execArgv.includes('--test')
+if (!isTestRun) {
   puppeteer.use(StealthPlugin())
 }
 

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "main": "index.js",
   "scripts": {
     "lint": "node ./node_modules/eslint/bin/eslint.js . --ext .json --ext .js --fix",
-    "test": "NODE_ENV=test node --test",
+    "test": "node --test",
     "merge:csv": "node scripts/merge-csv.js",
     "sample:prepare": "node scripts/fetch-curated-urls.js",
     "sample:single": "node scripts/single-sample-run.js",


### PR DESCRIPTION
## Summary
- run tests with Node's built-in `--test` flag to avoid shell-specific `NODE_ENV` assignment
- remove `NODE_ENV` checks in modules in favor of Node `--test` flag detection


------
https://chatgpt.com/codex/tasks/task_e_68c047d1fd9083328fd48585b8ca8f54