### PR TITLE
Replace environment override with tweaks-file argument

### DIFF
--- a/README.md
+++ b/README.md
@@ -485,7 +485,7 @@ Notes
 
 Domain-specific navigation and header tweaks can be configured without changing code.
 
-- Config file: `scripts/crawl-tweaks.json` (override via `CRAWL_TWEAKS_FILE=/path/to/config.json`).
+- Config file: `scripts/crawl-tweaks.json` (override via `--tweaks-file /path/to/config.json`).
 - Two sections:
   - `rewrites`: URL rewrites applied before crawling (e.g., normalize feed wrappers).
   - `rules`: per-domain behavior overrides (disable interception, adjust `goto` wait/timeout, add headers, set retries).

--- a/scripts/batch-crawl.js
+++ b/scripts/batch-crawl.js
@@ -35,14 +35,14 @@ export function uniqueByHost(urls, limit = Infinity) {
   }
   return out
 }
-export async function run(urlsFile, outCsv = 'candidates_with_url.csv', start = 0, limit = null, concurrency = 1, uniqueHosts = false, progressOnly = false, barWidth = 16) {
+export async function run(urlsFile, outCsv = 'candidates_with_url.csv', start = 0, limit = null, concurrency = 1, uniqueHosts = false, progressOnly = false, barWidth = 16, tweaksFile) {
   let all = readUrls(urlsFile)
   if (uniqueHosts) all = uniqueByHost(all)
   const end = limit ? Math.min(all.length, Number(start) + Number(limit)) : all.length
   const urls = all.slice(Number(start) || 0, end)
 
   const quiet = progressOnly // suppress per-URL logs when using progress bar
-  const tweaksConfig = loadTweaksConfig()
+  const tweaksConfig = loadTweaksConfig(tweaksFile)
   const t0 = Date.now()
   let processed = 0
   let okCount = 0
@@ -198,7 +198,8 @@ if (isCli) {
       concurrency: { type: 'string', default: '1' },
       'unique-hosts': { type: 'boolean', default: false },
       'progress-only': { type: 'boolean', default: false },
-      'bar-width': { type: 'string', default: '16' }
+      'bar-width': { type: 'string', default: '16' },
+      'tweaks-file': { type: 'string' }
     }
   })
   const urlsFile = values['urls-file']
@@ -208,5 +209,5 @@ if (isCli) {
   const concurrency = Number(values.concurrency)
   const uniqueHosts = values['unique-hosts']
   const barWidth = Number(values['bar-width'])
-  run(urlsFile, outCsv, start, limit, concurrency, uniqueHosts, values['progress-only'], barWidth).catch(err => { logger.error(err); throw err })
+  run(urlsFile, outCsv, start, limit, concurrency, uniqueHosts, values['progress-only'], barWidth, values['tweaks-file']).catch(err => { logger.error(err); throw err })
 }

--- a/scripts/batch-sample-run.js
+++ b/scripts/batch-sample-run.js
@@ -255,7 +255,8 @@ async function main() {
       'unique-hosts': { type: 'boolean', default: false },
       'progress-only': { type: 'boolean', default: false },
       'bar-width': { type: 'string', default: '16' },
-      'verbose': { type: 'boolean', default: false }
+      'verbose': { type: 'boolean', default: false },
+      'tweaks-file': { type: 'string' }
     }
   })
   const N = Number(values.count)
@@ -268,7 +269,7 @@ async function main() {
   const verbose = values.verbose
   const quiet = verbose ? false : (concurrency > 1)
 
-  const tweaks = loadTweaksConfig()
+  const tweaks = loadTweaksConfig(values['tweaks-file'])
   let urls = uniq(readUrls(urlsFile))
   if (uniqueHosts) urls = uniqueByHost(urls, N)
   if (!uniqueHosts && urls.length > N) urls = urls.slice(0, N)

--- a/scripts/inc/applyDomainTweaks.js
+++ b/scripts/inc/applyDomainTweaks.js
@@ -94,8 +94,7 @@ export function applyDomainTweaks(url, options, config, context = {}) {
 }
 
 export function loadTweaksConfig(configPath) {
-  const envPath = process.env.CRAWL_TWEAKS_FILE
-  const p = envPath || configPath || path.resolve('scripts/crawl-tweaks.json')
+  const p = configPath || path.resolve('scripts/crawl-tweaks.json')
   return loadConfig(p)
 }
 

--- a/scripts/single-sample-run.js
+++ b/scripts/single-sample-run.js
@@ -17,9 +17,10 @@ const testPlugin = function (Doc, world) {
 
 // Allow passing a URL via CLI: `node scripts/single-sample-run.js --url <url> --timeout <ms>`
 // With npm: `npm run sample:single -- --url <url> --timeout <ms>`
-const { values } = parseArgs({ options: { url: { type: 'string' }, timeout: { type: 'string' } } })
+const { values } = parseArgs({ options: { url: { type: 'string' }, timeout: { type: 'string' }, 'tweaks-file': { type: 'string' } } })
 const inputUrl = values.url || null
 const timeoutMs = Number(values.timeout || 40000)
+const tweaksFile = values['tweaks-file']
 
 const options = {
   timeoutMs,
@@ -76,7 +77,7 @@ try {
 
 // Apply crawl tweaks (rewrites, headers, goto, consent clicks, interception) from scripts/crawl-tweaks.json
 try {
-  const tweaks = loadTweaksConfig()
+  const tweaks = loadTweaksConfig(tweaksFile)
   if (tweaks) {
     // Apply URL rewrites first
     const rewritten = applyUrlRewrites(options.url, tweaks)


### PR DESCRIPTION
## Summary
- switch config loader to accept tweaks file path instead of CRAWL_TWEAKS_FILE
- add `--tweaks-file` CLI option to batch and sample scripts
- document argument-based override for crawl tweaks configuration

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c04f98c28c8332a86ef24dd41c9318