### PR TITLE
Always enable stealth plugin and document Chrome/NVM setup

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,7 +1,14 @@
 # AGENTS
 
-- Install Google Chrome and its required system libraries (e.g. `fonts-liberation`, `libasound2`, `libatk-bridge2.0-0`, `libgtk-3-0`, `libnss3`, `libx11-xcb1`, `libxkbcommon0`, `libu2f-udev`) then verify it immediately with:
-  - `google-chrome --version`
-- Install Node.js dependencies and confirm `cross-env` is present:
+- Install Google Chrome and its required system libraries quickly:
+  - `apt-get update`
+  - `wget -q https://dl.google.com/linux/direct/google-chrome-stable_current_amd64.deb`
+  - `apt-get install -y --no-install-recommends ./google-chrome-stable_current_amd64.deb fonts-liberation libasound2t64 libatk-bridge2.0-0t64 libgtk-3-0t64 libnss3 libx11-xcb1 libxkbcommon0 libu2f-udev`
+  - Verify installation with `google-chrome --version`
+- Install Node.js using NVM and install dependencies:
+  - `curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.5/install.sh | bash`
+  - `export NVM_DIR="$HOME/.nvm"`
+  - `[ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh"`
+  - `nvm install --lts`
+  - `node --version`
   - `npm install`
-  - `npm list cross-env`

--- a/index.js
+++ b/index.js
@@ -1,10 +1,7 @@
 import puppeteer from 'puppeteer-extra'
 import StealthPlugin from 'puppeteer-extra-plugin-stealth'
 
-const isTestRun = process.execArgv.includes('--test')
-if (!isTestRun) {
-  puppeteer.use(StealthPlugin())
-}
+puppeteer.use(StealthPlugin())
 
 import fs from 'fs'
 import Sentiment from 'sentiment'


### PR DESCRIPTION
## Summary
- Always apply `puppeteer-extra` StealthPlugin regardless of test mode
- Document Chrome installation and NVM-based Node setup for faster environment setup

## Testing
- `google-chrome --version`
- `node --version`
- `npm install`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c055b60b1c83328bd328392d00e244