### PR TITLE
refactor parser into modular helpers and tighten error logging

### DIFF
--- a/controllers/async.js
+++ b/controllers/async.js
@@ -1,0 +1,16 @@
+import logger from './logger.js'
+
+/**
+ * Safely await a promise and log any error.
+ * @param {Promise} promise the promise to await
+ * @param {string} [msg] optional message prefix
+ * @returns {Promise<*>} resolved value or undefined on error
+ */
+export async function safeAwait (promise, msg = 'Async operation failed') {
+  try {
+    return await promise
+  } catch (err) {
+    logger.warn(`${msg}: ${err.message}`)
+    return undefined
+  }
+}

--- a/controllers/navigation.js
+++ b/controllers/navigation.js
@@ -1,0 +1,61 @@
+import logger from './logger.js'
+import { sanitizeDataUrl } from './utils.js'
+import { safeAwait } from './async.js'
+
+export const timeLeftFactory = (options) => () => {
+  try { if (!options.__deadline) return Infinity } catch { return Infinity }
+  return Math.max(0, options.__deadline - Date.now())
+}
+
+export async function waitForFrameStability (page, timeLeft, quietMs = 400, maxMs = 1500) {
+  const start = Date.now()
+  const deadline = Math.min(maxMs, timeLeft())
+  await safeAwait(page.waitForFunction(() => document.readyState === 'complete', { timeout: Math.min(1200, Math.max(0, timeLeft())) }), 'readyState wait')
+  while ((Date.now() - (page.__lastNavAt || 0)) < quietMs && (Date.now() - start) < deadline) {
+    const slice = Math.min(120, Math.max(40, quietMs / 4))
+    await safeAwait(page.waitForTimeout(slice), 'waitForTimeout')
+  }
+}
+
+export async function navigateWithFallback (page, options, url, timeLeft, log, interceptionActiveRef) {
+  if (url.startsWith('data:')) {
+    const { html, sanitizedUrl } = sanitizeDataUrl(url, options.puppeteer?.launch?.javascriptEnabled !== false)
+    await page.setContent(html, { waitUntil: 'domcontentloaded', timeout: 0 })
+    return { url: sanitizedUrl, status: 200 }
+  }
+
+  const headersBackup = options.puppeteer?.extraHTTPHeaders ? { ...options.puppeteer.extraHTTPHeaders } : {}
+  const tryGoto = async (gotoOpts) => page.goto(url, gotoOpts)
+  let response
+  try {
+    const baseTimeout = Math.min(7000, Math.max(3000, timeLeft()))
+    const go = Object.assign({ waitUntil: 'domcontentloaded', timeout: baseTimeout }, options.puppeteer.goto || {})
+    if (!Number.isFinite(go.timeout)) go.timeout = baseTimeout
+    log('nav', 'attempt', { wait_until: go.waitUntil, timeout_ms: go.timeout })
+    response = await tryGoto(go)
+  } catch (err1) {
+    logger.warn('navigation attempt failed', err1)
+    try {
+      response = await tryGoto({ waitUntil: 'domcontentloaded', timeout: Math.min(5000, Math.max(2500, timeLeft())) })
+    } catch (err2) {
+      logger.warn('navigation retry failed', err2)
+      try {
+        await safeAwait(page.setRequestInterception(false), 'disable interception')
+        if (interceptionActiveRef) interceptionActiveRef.current = false
+        response = await tryGoto({ waitUntil: 'domcontentloaded', timeout: Math.min(4000, Math.max(2000, timeLeft())) })
+      } catch (err3) {
+        logger.warn('navigation fallback failed', err3)
+        await safeAwait(page.setExtraHTTPHeaders({ ...headersBackup, Referer: 'https://www.google.com/' }), 'setExtraHTTPHeaders')
+        try {
+          response = await tryGoto({ waitUntil: 'domcontentloaded', timeout: Math.min(4000, Math.max(2000, timeLeft())) })
+        } catch (err4) {
+          log('nav', 'failed', { error: err4.message })
+          throw new Error('Failed to fetch ' + url + ': ' + err4.message)
+        } finally {
+          await safeAwait(page.setExtraHTTPHeaders(headersBackup), 'restore headers')
+        }
+      }
+    }
+  }
+  return response
+}

--- a/controllers/nlpPlugins.js
+++ b/controllers/nlpPlugins.js
@@ -1,0 +1,21 @@
+import nlp from 'compromise'
+import logger from './logger.js'
+
+export function loadNlpPlugins (options) {
+  const hints = { first: [], last: [] }
+  if (!options?.nlp?.plugins?.length) return hints
+  for (const plugin of options.nlp.plugins) {
+    try { nlp.plugin(plugin) } catch (err) { logger.warn('nlp plugin load failed', err) }
+    try {
+      plugin(null, {
+        addWords: (words = {}) => {
+          for (const [w, tag] of Object.entries(words)) {
+            if (/^first/i.test(tag)) hints.first.push(w)
+            else if (/^last/i.test(tag)) hints.last.push(w)
+          }
+        }
+      })
+    } catch (err) { logger.warn('nlp plugin init failed', err) }
+  }
+  return hints
+}

--- a/controllers/textProcessing.js
+++ b/controllers/textProcessing.js
@@ -37,17 +37,14 @@ export function getRawText (html) {
   return rawText.replace(/\s+/g, ' ').trim()
 }
 
-export function getFormattedText (html, title, baseurl, options) {
-  if (typeof options === 'undefined') {
-    options = {
-      wordwrap: 100,
-      noLinkBrackets: true,
-      ignoreHref: true,
-      tables: true,
-      uppercaseHeadings: true,
-      linkHrefBaseUrl: baseurl
-    }
-  }
+export function getFormattedText (html, title, baseurl, options = {
+  wordwrap: 100,
+  noLinkBrackets: true,
+  ignoreHref: true,
+  tables: true,
+  uppercaseHeadings: true,
+  linkHrefBaseUrl: baseurl
+}) {
   if (typeof options.linkHrefBaseUrl === 'undefined') {
     options.linkHrefBaseUrl = baseurl
   }
@@ -69,15 +66,12 @@ export function getHtmlText (text) {
   return textArray.join('\n')
 }
 
-export function htmlCleaner (html, options) {
+export function htmlCleaner (html, options = {
+  'add-remove-tags': ['blockquote', 'span'],
+  'remove-empty-tags': ['span'],
+  'replace-nbsp': true
+}) {
   return new Promise((resolve) => {
-    if (typeof options === 'undefined') {
-      options = {
-        'add-remove-tags': ['blockquote', 'span'],
-        'remove-empty-tags': ['span'],
-        'replace-nbsp': true
-      }
-    }
     cleaner.clean(html, options, function (out) {
       resolve(out)
     })

--- a/controllers/utils.js
+++ b/controllers/utils.js
@@ -1,0 +1,28 @@
+import logger from './logger.js'
+
+/**
+ * Sanitize a data: URL by stripping scripts when JS is disabled
+ * and return both sanitized HTML and URL.
+ *
+ * @param {string} rawUrl original data URL
+ * @param {boolean} jsEnabled whether JavaScript is enabled
+ * @returns {{html: string, sanitizedUrl: string}}
+ */
+export function sanitizeDataUrl (rawUrl, jsEnabled = true) {
+  try {
+    const idx = rawUrl.indexOf(',')
+    const meta = rawUrl.slice(0, idx)
+    const payload = rawUrl.slice(idx + 1)
+    const html = meta.includes(';base64')
+      ? Buffer.from(payload, 'base64').toString('utf8')
+      : decodeURIComponent(payload)
+    const sanitized = jsEnabled
+      ? html
+      : html.replace(/<script[^>]*>[\s\S]*?<\/script>/gi, '')
+    const sanitizedUrl = 'data:text/html;base64,' + Buffer.from(sanitized).toString('base64')
+    return { html: sanitized, sanitizedUrl }
+  } catch (err) {
+    logger.warn('sanitizeDataUrl failed', err)
+    return { html: '', sanitizedUrl: rawUrl }
+  }
+}

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -38,7 +38,7 @@ export default [
     },
     rules: {
       'no-prototype-builtins': 'off',
-      'no-empty': 'off',
+      'no-empty': ['error', { allowEmptyCatch: true }],
       'no-unused-vars': 'off',
       'promise/param-names': 'off',
       'n/no-process-exit': 'off',


### PR DESCRIPTION
## Summary
- modularize navigation and plugin handling to slim index.js
- sanitize data URLs and add default parameters for text helpers
- introduce safeAwait for consistent error logging
- enable eslint `no-empty` rule while allowing empty catches

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c05fdde6008332b1091251e8e03b1f