### PR TITLE
refactor: replace waitForTimeout usage

### DIFF
--- a/controllers/async.js
+++ b/controllers/async.js
@@ -14,3 +14,10 @@ export async function safeAwait (promise, msg = 'Async operation failed') {
     return undefined
   }
 }
+
+/**
+ * Sleep for a specified number of milliseconds.
+ * @param {number} ms time in milliseconds
+ * @returns {Promise<void>}
+ */
+export const sleep = ms => new Promise(resolve => setTimeout(resolve, ms))

--- a/controllers/consent.js
+++ b/controllers/consent.js
@@ -1,3 +1,5 @@
+import { sleep } from './async.js'
+
 export async function autoDismissConsent (page, consentOptions = {}) {
   try {
     const selectors = Array.isArray(consentOptions.selectors) ? consentOptions.selectors : []
@@ -19,7 +21,7 @@ export async function autoDismissConsent (page, consentOptions = {}) {
             } catch {}
             await el.click({ delay: 20 })
             clicks++
-            await page.waitForTimeout(waitMs)
+            await sleep(waitMs)
           }
         } catch {}
       }
@@ -60,7 +62,7 @@ export async function autoDismissConsent (page, consentOptions = {}) {
           return count
         }, patterns, remaining)
         clicks += Number(did) || 0
-        if (did) await page.waitForTimeout(waitMs)
+        if (did) await sleep(waitMs)
       } catch {}
     }
 
@@ -80,6 +82,6 @@ export async function autoDismissConsent (page, consentOptions = {}) {
     }
 
     try { await page.keyboard.press('Escape') } catch {}
-    if (waitMs) await page.waitForTimeout(100)
+    if (waitMs) await sleep(100)
   } catch {}
 }

--- a/controllers/navigation.js
+++ b/controllers/navigation.js
@@ -1,6 +1,6 @@
 import logger from './logger.js'
 import { sanitizeDataUrl } from './utils.js'
-import { safeAwait } from './async.js'
+import { safeAwait, sleep } from './async.js'
 
 export const timeLeftFactory = (options) => () => {
   try { if (!options.__deadline) return Infinity } catch { return Infinity }
@@ -13,7 +13,7 @@ export async function waitForFrameStability (page, timeLeft, quietMs = 400, maxM
   await safeAwait(page.waitForFunction(() => document.readyState === 'complete', { timeout: Math.min(1200, Math.max(0, timeLeft())) }), 'readyState wait')
   while ((Date.now() - (page.__lastNavAt || 0)) < quietMs && (Date.now() - start) < deadline) {
     const slice = Math.min(120, Math.max(40, quietMs / 4))
-    await safeAwait(page.waitForTimeout(slice), 'waitForTimeout')
+    await safeAwait(sleep(slice), 'wait')
   }
 }
 

--- a/index.js
+++ b/index.js
@@ -21,7 +21,7 @@ import { autoDismissConsent } from './controllers/consent.js'
 import { buildLiveBlogSummary } from './controllers/liveBlog.js'
 import { getRawText, getFormattedText, getHtmlText, htmlCleaner } from './controllers/textProcessing.js'
 import { sanitizeDataUrl } from './controllers/utils.js'
-import { safeAwait } from './controllers/async.js'
+import { safeAwait, sleep } from './controllers/async.js'
 import { timeLeftFactory, waitForFrameStability, navigateWithFallback } from './controllers/navigation.js'
 import { loadNlpPlugins } from './controllers/nlpPlugins.js'
 
@@ -470,7 +470,7 @@ const articleParser = async function (browser, options, socket) {
       })
     })
     // small settle delay
-    await page.waitForTimeout(400)
+    await sleep(400)
     // Re-check preferred selectors after scroll
     const contentSelectors2 = options.contentWaitSelectors || [
       '.entry-content', '.post-body', '#postBody', '.post-content', '.article-content'
@@ -494,7 +494,7 @@ const articleParser = async function (browser, options, socket) {
           }, 120)
         })
       })
-      await page.waitForTimeout(300)
+      await sleep(300)
       for (const sel of contentSelectors2) {
         try { await page.waitForSelector(sel, { timeout: 2000 }) ; break } catch {}
       }
@@ -1005,7 +1005,7 @@ log('analyze', 'Evaluating meta tags')
     if (!contentOverridden && !staticHtmlOverride && rawLen < 200 && timeLeft() > 2000) {
       log('rescue', 'Low content detected; retrying detection', { chars: rawLen })
       try { await page.setRequestInterception(false) } catch {}
-      try { await page.waitForTimeout(800) } catch {}
+      try { await sleep(800) } catch {}
       try { await page.waitForNavigation({ waitUntil: 'networkidle2', timeout: Math.min(3000, Math.max(0, timeLeft())) }) } catch {}
       let freshHtml = null
       try { freshHtml = await evalWithRetry(async () => page.content()) } catch { freshHtml = null }


### PR DESCRIPTION
## Summary
- replace deprecated `page.waitForTimeout` calls with a generic `sleep` helper
- use `sleep` in frame stability waits and consent handling to avoid TypeErrors

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c0646d43c483329e561c9797a8f7a6