### PR TITLE
Speed up parseArticle tests

### DIFF
--- a/index.js
+++ b/index.js
@@ -419,30 +419,32 @@ const articleParser = async function (browser, options, socket) {
   } catch {}
 
   // Generic readable-content heuristic wait: paragraphs/headings/body text signals
-  try {
-    const maxMs = Math.min(2500, Math.max(800, tl()))
-    await page.waitForFunction(() => {
-      const scope = document.querySelector('article, main, [role="main"]') || document.body
-      if (!scope) return false
-      const paras = Array.from(scope.querySelectorAll('p'))
-      const heads = scope.querySelector('h1, h2, h3')
-      let longCount = 0
-      let blocksOver80 = 0
-      let totalText = 0
-      for (const p of paras) {
-        const t = (p.textContent || '').replace(/\s+/g, ' ').trim()
-        totalText += t.length
-        if (t.length >= 120) longCount++
-        if (t.length >= 80) blocksOver80++
-        if (longCount >= 2) return true
-      }
-      if (longCount >= 1 && !!heads) return true
-      if (blocksOver80 >= 3) return true
-      if (totalText >= 800) return true
-      return false
-    }, { timeout: maxMs })
-    log('content', 'readable_signal')
-  } catch {}
+  if (!options.skipReadabilityWait) {
+    try {
+      const maxMs = Math.min(2500, Math.max(800, tl()))
+      await page.waitForFunction(() => {
+        const scope = document.querySelector('article, main, [role="main"]') || document.body
+        if (!scope) return false
+        const paras = Array.from(scope.querySelectorAll('p'))
+        const heads = scope.querySelector('h1, h2, h3')
+        let longCount = 0
+        let blocksOver80 = 0
+        let totalText = 0
+        for (const p of paras) {
+          const t = (p.textContent || '').replace(/\s+/g, ' ').trim()
+          totalText += t.length
+          if (t.length >= 120) longCount++
+          if (t.length >= 80) blocksOver80++
+          if (longCount >= 2) return true
+        }
+        if (longCount >= 1 && !!heads) return true
+        if (blocksOver80 >= 3) return true
+        if (totalText >= 800) return true
+        return false
+      }, { timeout: maxMs })
+      log('content', 'readable_signal')
+    } catch {}
+  }
 
   // If AMP fetched, prefer static override for speed and robustness
   try {

--- a/tests/fixtures/integration/sample.html
+++ b/tests/fixtures/integration/sample.html
@@ -5,7 +5,14 @@
   </head>
   <body>
     <article>
-      <p>This is a sample article with a missspelled word.</p>
+      <p>
+        This is a sample article with a missspelled word. It contains multiple
+        sentences to ensure the text exceeds two hundred characters, allowing
+        the parser to avoid triggering any slow rescue logic during tests. The
+        additional filler content keeps the example realistic while providing
+        ample length for analysis and spelling checks.
+      </p>
+      <p>Another short paragraph keeps the document realistic.</p>
       <a href="https://example.com">Example link</a>
     </article>
   </body>

--- a/tests/parseArticle.test.js
+++ b/tests/parseArticle.test.js
@@ -1,32 +1,63 @@
-import { test } from 'node:test'
+import { test, before, after } from 'node:test'
 import assert from 'node:assert/strict'
 import fs from 'fs'
 import http from 'node:http'
+import puppeteer from 'puppeteer-extra'
 import { parseArticle } from '../index.js'
 
 // Silent socket to suppress parser status logs during tests
 const quietSocket = { emit: () => {} }
 
-test('parseArticle processes local HTML', async (t) => {
-  const html = fs.readFileSync('tests/fixtures/integration/sample.html', 'utf8')
-  const dataUrl = 'data:text/html;base64,' + Buffer.from(html).toString('base64')
-  try {
-    const article = await parseArticle({
-      url: dataUrl,
-      enabled: ['spelling'],
-      timeoutMs: 20000,
-      puppeteer: { launch: { headless: true, args: ['--no-sandbox', '--disable-setuid-sandbox'] } }
-    }, quietSocket)
-    assert.equal(article.title.text, 'Sample Story')
-    assert.ok(article.links.some(l => /example\.com/.test(l.href)))
-    assert.ok(article.spelling.some(s => s.word.toLowerCase().includes('missspelled')))
-  } catch (err) {
-    t.skip('puppeteer unavailable: ' + err.message)
-  }
+// Shorten test and parser timeouts to speed up the suite
+const TEST_TIMEOUT = 10000
+const PARSE_TIMEOUT = 8000
+
+// Reuse a single browser instance across tests to avoid repeated startups
+let sharedBrowser
+let originalLaunch
+let originalClose
+
+before(async () => {
+  originalLaunch = puppeteer.launch
+  const boundLaunch = puppeteer.launch.bind(puppeteer)
+  sharedBrowser = await boundLaunch({ headless: true, args: ['--no-sandbox', '--disable-setuid-sandbox'] })
+  originalClose = sharedBrowser.close.bind(sharedBrowser)
+  // Prevent individual tests from closing the shared browser
+  sharedBrowser.close = async () => {}
+  puppeteer.launch = async () => sharedBrowser
 })
 
-test('parseArticle uses rules overrides for title and content', async (t) => {
-  const html = '<html><head><title>Wrong</title></head><body><article><p>Incorrect</p></article></body></html>'
+after(async () => {
+  puppeteer.launch = originalLaunch
+  if (originalClose) await originalClose()
+})
+
+test('parseArticle processes local HTML', { timeout: TEST_TIMEOUT }, async (t) => {
+  const html = fs.readFileSync('tests/fixtures/integration/sample.html', 'utf8')
+  const dataUrl = 'data:text/html;base64,' + Buffer.from(html).toString('base64')
+  let article
+  try {
+    article = await parseArticle({
+      url: dataUrl,
+      enabled: ['spelling'],
+      timeoutMs: PARSE_TIMEOUT,
+      contentWaitSelectors: ['article'],
+      contentWaitTimeoutMs: 1,
+      skipReadabilityWait: true,
+      puppeteer: { launch: { headless: true, args: ['--no-sandbox', '--disable-setuid-sandbox'] } }
+    }, quietSocket)
+  } catch (err) {
+    t.skip('puppeteer unavailable: ' + err.message)
+    return
+  }
+  assert.equal(article.title.text, 'Sample Story')
+  assert.ok(article.links.some(l => /example\.com/.test(l.href)))
+  assert.ok(article.spelling.some(s => s.word.toLowerCase().includes('missspelled')))
+})
+
+test('parseArticle uses rules overrides for title and content', { timeout: TEST_TIMEOUT }, async (t) => {
+  const longText = 'Incorrect '.repeat(30)
+  const html = `<html><head><title>Wrong</title></head><body><article><p>${longText}</p></article></body></html>`
   const server = http.createServer((req, res) => {
     res.end(html)
   })
@@ -34,41 +65,51 @@ test('parseArticle uses rules overrides for title and content', async (t) => {
   const { port } = server.address()
   const url = `http://127.0.0.1:${port}`
 
+  let baseline, article
   try {
-    const baseline = await parseArticle({
+    baseline = await parseArticle({
       url,
-      timeoutMs: 20000,
+      timeoutMs: PARSE_TIMEOUT,
+      contentWaitSelectors: ['article'],
+      contentWaitTimeoutMs: 1,
+      skipReadabilityWait: true,
       puppeteer: { launch: { headless: true, args: ['--no-sandbox', '--disable-setuid-sandbox'] } }
     }, quietSocket)
-    assert.equal(baseline.title.text, 'Wrong')
-    assert.equal(baseline.processed.text.raw.trim(), 'Incorrect')
-
-    const article = await parseArticle({
+    article = await parseArticle({
       url,
       rules: [{
         host: `127.0.0.1:${port}`,
         title: () => 'Right',
         content: () => '<article><p>Correct</p></article>'
       }],
-      timeoutMs: 20000,
+      timeoutMs: PARSE_TIMEOUT,
+      contentWaitSelectors: ['article'],
+      contentWaitTimeoutMs: 1,
+      skipReadabilityWait: true,
       puppeteer: { launch: { headless: true, args: ['--no-sandbox', '--disable-setuid-sandbox'] } }
     }, quietSocket)
-    assert.equal(article.title.text, 'Right')
-    assert.equal(article.processed.text.raw.trim(), 'Correct')
   } catch (err) {
     t.skip('puppeteer unavailable: ' + err.message)
-  } finally {
     server.close()
+    return
   }
+  assert.equal(baseline.title.text, 'Wrong')
+  assert.ok(baseline.processed.text.raw.trim().startsWith('Incorrect'))
+  assert.equal(article.title.text, 'Right')
+  assert.equal(article.processed.text.raw.trim(), 'Correct')
+  server.close()
 })
 
-test('parseArticle respects timeoutMs option', async (t) => {
+test('parseArticle respects timeoutMs option', { timeout: TEST_TIMEOUT }, async (t) => {
   const html = '<html><head><title>Timeout Test</title></head><body><article><p>content</p></article></body></html>'
   const dataUrl = 'data:text/html;base64,' + Buffer.from(html).toString('base64')
   try {
     await parseArticle({
       url: dataUrl,
       timeoutMs: 1,
+      contentWaitSelectors: ['article'],
+      contentWaitTimeoutMs: 1,
+      skipReadabilityWait: true,
       puppeteer: { launch: { headless: true, args: ['--no-sandbox', '--disable-setuid-sandbox'] } }
     }, quietSocket)
     t.fail('Expected parse to timeout')
@@ -81,47 +122,62 @@ test('parseArticle respects timeoutMs option', async (t) => {
   }
 })
 
-test('parseArticle can disable JavaScript execution', async (t) => {
-  const html = '<html><head><title>Original</title><script>document.title="Changed"</script></head><body><article><p>content</p></article></body></html>'
+test('parseArticle can disable JavaScript execution', { timeout: TEST_TIMEOUT }, async (t) => {
+  const filler = 'more text '.repeat(30)
+  const html = `<html><head><title>Original</title><script>document.title="Changed"</script></head><body><article><p>content ${filler}</p></article></body></html>`
   const dataUrl = 'data:text/html;base64,' + Buffer.from(html).toString('base64')
+  let withJs, withoutJs
   try {
-    const withJs = await parseArticle({
+    withJs = await parseArticle({
       url: dataUrl,
-      timeoutMs: 20000,
+      timeoutMs: PARSE_TIMEOUT,
+      contentWaitSelectors: ['article'],
+      contentWaitTimeoutMs: 1,
+      skipReadabilityWait: true,
       puppeteer: { launch: { headless: true, args: ['--no-sandbox', '--disable-setuid-sandbox'] } }
     }, quietSocket)
-    assert.equal(withJs.title.text, 'Changed')
-
-    const withoutJs = await parseArticle({
+    withoutJs = await parseArticle({
       url: dataUrl,
-      timeoutMs: 20000,
+      timeoutMs: PARSE_TIMEOUT,
+      contentWaitSelectors: ['article'],
+      contentWaitTimeoutMs: 1,
+      skipReadabilityWait: true,
       puppeteer: { launch: { headless: true, args: ['--no-sandbox', '--disable-setuid-sandbox'], javascriptEnabled: false } }
     }, quietSocket)
-    assert.equal(withoutJs.title.text, 'Original')
   } catch (err) {
     t.skip('puppeteer unavailable: ' + err.message)
+    return
   }
+  assert.equal(withJs.title.text, 'Changed')
+  assert.equal(withoutJs.title.text, 'Original')
 })
 
-test('parseArticle strips selectors listed in striptags', async (t) => {
-  const html = '<html><head><title>StripTags Test</title></head><body><article><div class="ad">Ad text</div><p id="remove-me">Should go</p><p>Keep me</p></article></body></html>'
+test('parseArticle strips selectors listed in striptags', { timeout: TEST_TIMEOUT }, async (t) => {
+  const keep = 'Keep me '.repeat(20)
+  const html = `<html><head><title>StripTags Test</title></head><body><article><div class="ad">Ad text</div><p id="remove-me">Should go</p><p>${keep}</p></article></body></html>`
   const dataUrl = 'data:text/html;base64,' + Buffer.from(html).toString('base64')
+  let article
   try {
-    const article = await parseArticle({
+    article = await parseArticle({
       url: dataUrl,
       striptags: ['.ad', '#remove-me'],
-      timeoutMs: 20000,
+      timeoutMs: PARSE_TIMEOUT,
+      contentWaitSelectors: ['article'],
+      contentWaitTimeoutMs: 1,
+      skipReadabilityWait: true,
       puppeteer: { launch: { headless: true, args: ['--no-sandbox', '--disable-setuid-sandbox'] } }
     }, quietSocket)
-    assert.equal(article.title.text, 'StripTags Test')
-    assert.equal(article.processed.text.raw.trim(), 'Keep me')
   } catch (err) {
     t.skip('puppeteer unavailable: ' + err.message)
+    return
   }
+  assert.equal(article.title.text, 'StripTags Test')
+  assert.ok(article.processed.text.raw.trim().startsWith('Keep me'))
 })
 
-test('parseArticle applies custom Compromise plugins', async (t) => {
-  const html = fs.readFileSync('tests/fixtures/integration/rishi-sunak.html', 'utf8')
+test('parseArticle applies custom Compromise plugins', { timeout: TEST_TIMEOUT }, async (t) => {
+  const text = 'Prime minister Rishi Sunak spoke today '.repeat(10)
+  const html = `<html><head><title>Rishi Sunak</title></head><body><article><p>${text}</p></article></body></html>`
   const dataUrl = 'data:text/html;base64,' + Buffer.from(html).toString('base64')
 
   // Plugin from README example adds names to Compromise's lexicon
@@ -132,26 +188,33 @@ test('parseArticle applies custom Compromise plugins', async (t) => {
     })
   }
 
+  let withoutPlugin, withPlugin
   try {
-    const withoutPlugin = await parseArticle({
+    withoutPlugin = await parseArticle({
       url: dataUrl,
       enabled: ['entities'],
-      timeoutMs: 20000,
+      timeoutMs: PARSE_TIMEOUT,
+      contentWaitSelectors: ['article'],
+      contentWaitTimeoutMs: 1,
+      skipReadabilityWait: true,
       puppeteer: { launch: { headless: true, args: ['--no-sandbox', '--disable-setuid-sandbox'] } }
     }, quietSocket)
-    const foundWithout = Array.isArray(withoutPlugin.people) && withoutPlugin.people.some(p => /rishi/i.test(p.text))
-    assert.equal(foundWithout, false)
-
-    const withPlugin = await parseArticle({
+    withPlugin = await parseArticle({
       url: dataUrl,
       enabled: ['entities'],
       nlp: { plugins: [testPlugin] },
-      timeoutMs: 20000,
+      timeoutMs: PARSE_TIMEOUT,
+      contentWaitSelectors: ['article'],
+      contentWaitTimeoutMs: 1,
+      skipReadabilityWait: true,
       puppeteer: { launch: { headless: true, args: ['--no-sandbox', '--disable-setuid-sandbox'] } }
     }, quietSocket)
-    const foundWith = Array.isArray(withPlugin.people) && withPlugin.people.some(p => /rishi sunak/i.test(p.text))
-    assert.equal(foundWith, true)
   } catch (err) {
     t.skip('puppeteer unavailable: ' + err.message)
+    return
   }
+  const foundWithout = Array.isArray(withoutPlugin.people) && withoutPlugin.people.some(p => /rishi/i.test(p.text))
+  assert.equal(foundWithout, false)
+  const foundWith = Array.isArray(withPlugin.people) && withPlugin.people.some(p => /rishi sunak/i.test(p.text))
+  assert.equal(foundWith, true)
 })


### PR DESCRIPTION
## Summary
- add `skipReadabilityWait` flag to bypass costly content heuristics
- streamline parseArticle tests with explicit selectors and longer fixtures to avoid fallback waits
- use a lightweight HTML sample for plugin tests

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c06f0a2aa483329ae7ad22c241d2d5