### PR TITLE
Silence Windows taskkill errors

### DIFF
--- a/scripts/batch-crawl.js
+++ b/scripts/batch-crawl.js
@@ -7,6 +7,10 @@ import { applyDomainTweaks, loadTweaksConfig, applyUrlRewrites } from './inc/app
 import logger, { createLogger } from '../controllers/logger.js'
 import { fileURLToPath } from 'url'
 import { parseArgs } from 'node:util'
+import { suppressTaskkillErrors } from './inc/suppressTaskkillErrors.js'
+
+// Silence noisy Windows taskkill errors when cleaning up Chromium
+suppressTaskkillErrors()
 
 const progressLogger = createLogger()
 

--- a/scripts/batch-sample-run.js
+++ b/scripts/batch-sample-run.js
@@ -5,6 +5,10 @@ import { applyDomainTweaks, loadTweaksConfig, applyUrlRewrites } from './inc/app
 import logger, { createLogger } from '../controllers/logger.js'
 import { fileURLToPath } from 'url'
 import { parseArgs } from 'node:util'
+import { suppressTaskkillErrors } from './inc/suppressTaskkillErrors.js'
+
+// Silence noisy Windows taskkill errors when cleaning up Chromium
+suppressTaskkillErrors()
 
 const progressLogger = createLogger()
 

--- a/scripts/inc/suppressTaskkillErrors.js
+++ b/scripts/inc/suppressTaskkillErrors.js
@@ -1,0 +1,12 @@
+export function suppressTaskkillErrors() {
+  if (process.platform !== 'win32') return
+  const originalWrite = process.stderr.write.bind(process.stderr)
+  process.stderr.write = (chunk, encoding, cb) => {
+    const msg = typeof chunk === 'string' ? chunk : chunk.toString(encoding)
+    if (/^ERROR: The process with PID \d+/.test(msg) || /^Reason: (The operation attempted is not supported|There is no running instance of the task)/i.test(msg)) {
+      if (typeof cb === 'function') cb()
+      return true
+    }
+    return originalWrite(chunk, encoding, cb)
+  }
+}

--- a/scripts/single-sample-run.js
+++ b/scripts/single-sample-run.js
@@ -6,6 +6,10 @@ import fs from 'fs'
 import assert from 'assert'
 import logger from '../controllers/logger.js'
 import { parseArgs } from 'node:util'
+import { suppressTaskkillErrors } from './inc/suppressTaskkillErrors.js'
+
+// Silence noisy Windows taskkill errors when cleaning up Chromium
+suppressTaskkillErrors()
 
 /** add some names | https://observablehq.com/@spencermountain/compromise-plugins */
 const testPlugin = function (Doc, world) {


### PR DESCRIPTION
## Summary
- add helper to filter Windows `taskkill` stderr noise
- use helper in batch crawling scripts to keep output clean

## Testing
- `npm test`
- `npm run lint`
- `npm run sample:batch -- --count 1 --concurrency 1 --urls-file scripts/data/urls.txt --timeout 20000 --unique-hosts --progress-only`


------
https://chatgpt.com/codex/tasks/task_e_68c07f5733a48332a0491f456f80442b