### PR TITLE
test: add utility coverage

### DIFF
--- a/tests/async.test.js
+++ b/tests/async.test.js
@@ -1,0 +1,19 @@
+import { test } from 'node:test'
+import assert from 'node:assert/strict'
+import { safeAwait, sleep } from '../controllers/async.js'
+
+test('safeAwait returns resolved value', async () => {
+  const result = await safeAwait(Promise.resolve(42))
+  assert.equal(result, 42)
+})
+
+test('safeAwait returns undefined on rejection', async () => {
+  const result = await safeAwait(Promise.reject(new Error('fail')))
+  assert.equal(result, undefined)
+})
+
+test('sleep waits for at least specified time', async () => {
+  const start = Date.now()
+  await sleep(20)
+  assert.ok(Date.now() - start >= 20)
+})

--- a/tests/helpers.test.js
+++ b/tests/helpers.test.js
@@ -28,6 +28,12 @@ test('setDefaultOptions deeply merges nested structures', () => {
   assert.equal(opts.puppeteer.goto.waitUntil, 'domcontentloaded')
 })
 
+test('setDefaultOptions does not duplicate links in enabled array', () => {
+  const opts = setDefaultOptions({ enabled: ['links', 'extra'] })
+  const linkCount = opts.enabled.filter(e => e === 'links').length
+  assert.equal(linkCount, 1)
+})
+
 test('capitalizeFirstLetter capitalizes only first character', () => {
   assert.equal(capitalizeFirstLetter('hello'), 'Hello')
 })

--- a/tests/utils.test.js
+++ b/tests/utils.test.js
@@ -1,0 +1,18 @@
+import { test } from 'node:test'
+import assert from 'node:assert/strict'
+import { sanitizeDataUrl } from '../controllers/utils.js'
+
+const sampleHtml = '<html><body><script>evil()</script><p>Safe</p></body></html>'
+const dataUrl = 'data:text/html;base64,' + Buffer.from(sampleHtml).toString('base64')
+
+test('sanitizeDataUrl removes scripts when JavaScript is disabled', () => {
+  const { html, sanitizedUrl } = sanitizeDataUrl(dataUrl, false)
+  assert.ok(!html.includes('<script>'))
+  const decoded = Buffer.from(sanitizedUrl.split(',')[1], 'base64').toString('utf8')
+  assert.ok(!decoded.includes('<script>'))
+})
+
+test('sanitizeDataUrl retains scripts when JavaScript is enabled', () => {
+  const { html } = sanitizeDataUrl(dataUrl, true)
+  assert.ok(html.includes('<script>'))
+})


### PR DESCRIPTION
## Summary
- cover `sanitizeDataUrl` to ensure scripts are stripped when JavaScript is disabled
- verify `safeAwait` behavior on resolve/reject and timing for `sleep`
- ensure `setDefaultOptions` avoids duplicate `links`

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c082667a2c833286e03a567013e58f