### PR TITLE
Enable screenshot capture in parseArticle

### DIFF
--- a/index.js
+++ b/index.js
@@ -59,14 +59,6 @@ export async function parseArticle (options, socket = { emit: (type, status) => 
   } catch (err) {
     logger.warn('timeout heuristic failed', err)
   }
-  // Enforce no-screenshot globally regardless of caller configuration
-  try {
-    if (Array.isArray(options.enabled)) {
-      options.enabled = options.enabled.filter(k => k !== 'screenshot')
-    }
-  } catch (err) {
-    logger.warn('failed to filter enabled features', err)
-  }
 
   const pluginHints = loadNlpPlugins(options)
   options.__pluginHints = pluginHints

--- a/scripts/single-sample-run.js
+++ b/scripts/single-sample-run.js
@@ -29,7 +29,7 @@ const tweaksFile = values['tweaks-file']
 const options = {
   timeoutMs,
   url: inputUrl || 'https://www.bbc.co.uk/news/articles/cnvryg271ymo?at_medium=RSS&at_campaign=rss',
-  enabled: ['links', 'sentiment', 'entities', 'spelling', 'keywords', 'siteicon'],
+  enabled: ['links', 'sentiment', 'entities', 'spelling', 'keywords', 'siteicon', 'screenshot'],
   // In tests, lightly block heavy resources (keep images)
   blockedResourceTypes: ['media', 'font', 'stylesheet'],
   // Tune content detection thresholds and dump candidate features for training
@@ -108,6 +108,7 @@ const __dirname = path.dirname(fileURLToPath(import.meta.url))
       metadescription: article.meta.description.text,
       url: article.url,
       siteicon: article.siteicon,
+      mobile: article.mobile,
       sentiment: { score: article.sentiment.score, comparative: article.sentiment.comparative },
       keyphrases: article.processed.keyphrases,
       keywords: article.processed.keywords,

--- a/tests/parseArticle.test.js
+++ b/tests/parseArticle.test.js
@@ -55,6 +55,28 @@ test('parseArticle processes local HTML', { timeout: TEST_TIMEOUT }, async (t) =
   assert.ok(article.spelling.some(s => s.word.toLowerCase().includes('missspelled')))
 })
 
+test('parseArticle captures a screenshot when enabled', { timeout: TEST_TIMEOUT }, async (t) => {
+  const html = '<html><head><title>Shot</title></head><body><article><p>content</p></article></body></html>'
+  const dataUrl = 'data:text/html;base64,' + Buffer.from(html).toString('base64')
+  let article
+  try {
+    article = await parseArticle({
+      url: dataUrl,
+      enabled: ['screenshot'],
+      timeoutMs: PARSE_TIMEOUT,
+      contentWaitSelectors: ['article'],
+      contentWaitTimeoutMs: 1,
+      skipReadabilityWait: true,
+      puppeteer: { launch: { headless: true, args: ['--no-sandbox', '--disable-setuid-sandbox'] } }
+    }, quietSocket)
+  } catch (err) {
+    t.skip('puppeteer unavailable: ' + err.message)
+    return
+  }
+  assert.equal(typeof article.mobile, 'string')
+  assert.ok(Buffer.from(article.mobile, 'base64').length > 1000)
+})
+
 test('parseArticle uses rules overrides for title and content', { timeout: TEST_TIMEOUT }, async (t) => {
   const longText = 'Incorrect '.repeat(30)
   const html = `<html><head><title>Wrong</title></head><body><article><p>${longText}</p></article></body></html>`


### PR DESCRIPTION
## Summary
- allow `parseArticle` to honor the `screenshot` feature rather than filtering it out
- add regression test validating that a mobile screenshot is captured when the feature is enabled
- enable screenshot capture in the single sample script and include the image data in the JSON output

## Testing
- `npm test`
- `node scripts/single-sample-run.js`


------
https://chatgpt.com/codex/tasks/task_e_68c0988b50c88332b4e70ec038aab053