### PR TITLE
docs: document faster Chrome install

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,14 +1,25 @@
 # AGENTS
 
-- Install Google Chrome and its required system libraries quickly:
-  - `apt-get update`
-  - `wget -q https://dl.google.com/linux/direct/google-chrome-stable_current_amd64.deb`
-  - `apt-get install -y --no-install-recommends ./google-chrome-stable_current_amd64.deb fonts-liberation libasound2t64 libatk-bridge2.0-0t64 libgtk-3-0t64 libnss3 libx11-xcb1 libxkbcommon0 libu2f-udev`
-  - Verify installation with `google-chrome --version`
-- Install Node.js using NVM and install dependencies:
+- Install Node.js using NVM:
   - `curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.5/install.sh | bash`
   - `export NVM_DIR="$HOME/.nvm"`
-  - `[ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh"`
+  - `[ -s "$NVM_DIR/nvm.sh" ] && \\. "$NVM_DIR/nvm.sh"`
   - `nvm install --lts`
   - `node --version`
-  - `npm install`
+
+- Install Chrome's required system libraries before installing dependencies:
+  - `DEBIAN_FRONTEND=noninteractive apt-get update`
+  - `DEBIAN_FRONTEND=noninteractive apt-get install -y apt-utils`
+  - `DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends fonts-liberation libasound2t64 libatk-bridge2.0-0t64 libgtk-3-0t64 libnss3 libx11-xcb1 libxkbcommon0 libu2f-udev libgbm1`
+
+- Install project dependencies and Chrome. Preferred approach uses an npm-provided build for speed:
+  - `CI=1 npm ci`
+  - `CI=1 node node_modules/puppeteer/install.mjs`
+  - `export CHROME_PATH="$(node -e \"import('puppeteer').then(p => console.log(p.executablePath()));\")"`
+  - Verify installation with `CI=1 "$CHROME_PATH" --version`
+  - If the npm download fails, install Google Chrome from the .deb package instead:
+    - `wget -q https://dl.google.com/linux/direct/google-chrome-stable_current_amd64.deb`
+    - `DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends ./google-chrome-stable_current_amd64.deb fonts-liberation libasound2t64 libatk-bridge2.0-0t64 libgtk-3-0t64 libnss3 libx11-xcb1 libxkbcommon0 libu2f-udev libgbm1`
+    - `google-chrome --version`
+
+


### PR DESCRIPTION
## Summary
- install Node via NVM before installing Chrome
- install apt-utils and Chrome libraries before `npm ci`
- prefer Puppeteer's packaged Chrome with `.deb` fallback using noninteractive/CI flags
- remove test suite instruction from setup steps

## Testing
- `node --version`
- `CI=1 "$CHROME_PATH" --version`
- `CI=1 npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c162d96e3c8332ad9c3a1057e92127