### PR TITLE
Improve consent banner dismissal

### DIFF
--- a/helpers.js
+++ b/helpers.js
@@ -43,7 +43,7 @@ export function setDefaultOptions (options = {}) {
         'button[aria-label="Agree"]'
       ],
       textPatterns: [
-        'accept', 'accept all', 'accept and close', 'i accept', 'agree', 'i agree', 'yes i agree', "i'm ok with that", 'i am ok with that', 'ok', 'got it', 'continue', 'continue to site', 'allow all', 'consent', 'manage preferences'
+        'accept', 'accept all', 'accept and close', 'accept additional cookies', 'i accept', 'agree', 'i agree', 'yes i agree', "i'm ok with that", 'i am ok with that', 'ok', 'got it', 'continue', 'continue to site', 'allow all', 'consent', 'maybe later'
       ],
       waitAfterClickMs: 500,
       maxClicks: 3


### PR DESCRIPTION
## Summary
- remove retrying consent logic and redundant frame waits
- expand overlay dismissal to handle multiple banners and login prompts
- trim text patterns to always accept consent while adding site-specific phrases

## Testing
- `npm test`
- `node scripts/single-sample-run.js --url https://www.bbc.co.uk/news/articles/cderllgw84ro`
- `node scripts/single-sample-run.js --url https://www.theguardian.com/society/2025/sep/12/prison-officers-uk-skilled-work-visa-rule-change`


------
https://chatgpt.com/codex/tasks/task_e_68c4329c385083328736000c55ccc04a