### PR TITLE
feat: inject TCF API for consent

### DIFF
--- a/index.js
+++ b/index.js
@@ -17,7 +17,7 @@ import keywordParser from './controllers/keywordParser.js'
 import lighthouseAnalysis from './controllers/lighthouse.js'
 import spellCheck from './controllers/spellCheck.js'
 import logger from './controllers/logger.js'
-import { autoDismissConsent } from './controllers/consent.js'
+import { autoDismissConsent, injectTcfApi } from './controllers/consent.js'
 import { buildLiveBlogSummary } from './controllers/liveBlog.js'
 import { getRawText, getFormattedText, getHtmlText, htmlCleaner } from './controllers/textProcessing.js'
 import { sanitizeDataUrl } from './controllers/utils.js'
@@ -157,6 +157,9 @@ const articleParser = async function (browser, options, socket) {
   const page = await browser.newPage()
 
   try {
+    if (options.consent?.injectTcfApi) {
+      try { await injectTcfApi(page, options.consent) } catch (err) { logger.warn('injectTcfApi failed', err) }
+    }
     // Track frame navigations to wait for brief stability before evaluating
     page.__lastNavAt = Date.now()
     try {

--- a/tests/consent.test.js
+++ b/tests/consent.test.js
@@ -1,7 +1,7 @@
 import { test } from 'node:test'
 import assert from 'node:assert/strict'
 import puppeteer from 'puppeteer-extra'
-import { autoDismissConsent } from '../controllers/consent.js'
+import { autoDismissConsent, injectTcfApi } from '../controllers/consent.js'
 
 test('autoDismissConsent handles empty page', async () => {
   const page = {
@@ -57,5 +57,24 @@ test('autoDismissConsent dismisses overlay without consent keywords', async (t) 
   await autoDismissConsent(page, { textPatterns: ['accept all'] })
   const overlay = await page.$('.message-container')
   assert.equal(overlay, null)
+  await browser.close()
+})
+
+test('injectTcfApi sets __tcfapi with provided tcString', async (t) => {
+  let browser
+  try {
+    browser = await puppeteer.launch({ headless: true, args: ['--no-sandbox', '--disable-setuid-sandbox'] })
+  } catch (err) {
+    t.skip('puppeteer unavailable: ' + err.message)
+    return
+  }
+  const page = await browser.newPage()
+  await injectTcfApi(page, { tcString: 'teststring' })
+  await page.goto('data:text/html,<html><body>hi</body></html>')
+  const res = await page.evaluate(() => new Promise(resolve => {
+    window.__tcfapi('getTCData', 2, (d, s) => resolve({ d, s }))
+  }))
+  assert.equal(res.s, true)
+  assert.equal(res.d.tcString, 'teststring')
   await browser.close()
 })


### PR DESCRIPTION
## Summary
- stub TCF v2 CMP API so pages believe consent was granted
- call optional CMP injection before navigation
- test CMP stub wiring

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c450b470f88332b6fc1a190104951f