### PR TITLE
refine live blog detection

### DIFF
--- a/controllers/liveBlog.js
+++ b/controllers/liveBlog.js
@@ -26,12 +26,12 @@ export function buildLiveBlogSummary (document) {
       const hd = text(ttl)
       const pv = text(p)
       const score = (tt ? 1 : 0) + (hd.length > 12 ? 1 : 0) + (pv.length > 60 ? 1 : 0)
-      if (score >= 2) items.push({ time: tt, title: hd, body: pv })
+      if (score >= 2 && pv.length > 40) items.push({ time: tt, title: hd, body: pv })
       if (items.length >= MAX_UPDATES) break
     }
     if (items.length < 5) {
       const liveRoots = Array.from(document.querySelectorAll(
-        '.live, .live-blog, .liveblog, .timeline, .live_updates, .updates, .update, .post, [role="article"]'
+        '.live, .live-blog, .liveblog, .timeline, .live_updates, .updates, .update'
       )).slice(0, 200)
       for (const root of liveRoots) {
         if (!root) continue
@@ -71,7 +71,7 @@ export function buildLiveBlogSummary (document) {
       } catch {}
     }
     const totalBody = items.reduce((acc, it) => acc + (it.body ? it.body.length : 0), 0)
-    const enough = (items.length >= 3) || (items.length >= 2 && totalBody >= 500)
+    const enough = (items.length >= 3 && totalBody >= 200) || (items.length >= 2 && totalBody >= 500)
     if (enough) {
       const used = items.slice(0, 5)
       const html = ['<div class="live-summary">']

--- a/tests/liveBlog.test.js
+++ b/tests/liveBlog.test.js
@@ -20,6 +20,13 @@ test('buildLiveBlogSummary returns ok false when insufficient data', () => {
   assert.equal(res.ok, false)
 })
 
+test('buildLiveBlogSummary ignores time-only lists', () => {
+  const html = `\n  <div>\n    <div><time>1h ago</time><h2>One</h2></div>\n    <div><time>2h ago</time><h2>Two</h2></div>\n    <div><time>3h ago</time><h2>Three</h2></div>\n    <div><time>4h ago</time><h2>Four</h2></div>\n    <div><time>5h ago</time><h2>Five</h2></div>\n  </div>`
+  const { window } = new JSDOM(html)
+  const res = buildLiveBlogSummary(window.document)
+  assert.equal(res.ok, false)
+})
+
 test('buildLiveBlogSummary handles amp-live-list', () => {
   const html = fs.readFileSync('tests/fixtures/liveblog/amp.html', 'utf8')
   const { window } = new JSDOM(html)


### PR DESCRIPTION
## Summary
- require substantial body text before summarizing live blogs
- narrow live update selectors to avoid misclassification
- add regression test for time-only lists

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c4751fce608332bf0d5333f7abaf5f