### PR TITLE
Reduce consent wait and stabilize parseArticle screenshot test

### DIFF
--- a/controllers/consent.js
+++ b/controllers/consent.js
@@ -85,7 +85,10 @@ export async function autoDismissConsent (page, consentOptions = {}) {
 
     if (clicks) {
       try {
-        await page.waitForNavigation({ waitUntil: 'domcontentloaded', timeout: 2000 })
+        await Promise.race([
+          page.waitForNavigation({ waitUntil: 'domcontentloaded', timeout: 2000 }).catch(() => {}),
+          sleep(Math.min(waitMs, 1000))
+        ])
       } catch {}
     }
 

--- a/tests/parseArticle.test.js
+++ b/tests/parseArticle.test.js
@@ -12,7 +12,7 @@ const quietSocket = { emit: () => {} }
 
 // Shorten test and parser timeouts to speed up the suite
 const TEST_TIMEOUT = 10000
-const PARSE_TIMEOUT = 8000
+const PARSE_TIMEOUT = 10000
 
 // Reuse a single browser instance across tests to avoid repeated startups
 let sharedBrowser


### PR DESCRIPTION
## Summary
- Cut unnecessary navigation wait when auto-dismissing consent overlays
- Allow parseArticle screenshot test more time to finish

## Testing
- `npm run lint`
- `npm test -- tests/parseArticle.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68c47866771883328c889e71362dc356