### PR TITLE
Strip possessive endings from keywords and keyphrases

### DIFF
--- a/controllers/entityParser.js
+++ b/controllers/entityParser.js
@@ -1,5 +1,5 @@
 import nlp from 'compromise'
-import { capitalizeFirstLetter } from '../helpers.js'
+import { capitalizeFirstLetter, stripPossessive } from '../helpers.js'
 
 export function normalizeEntity (w) {
   if (typeof w !== 'string') return ''
@@ -11,11 +11,6 @@ export function normalizeEntity (w) {
 }
 
 export default function entityParser (nlpInput, pluginHints = { first: [], last: [] }, timeLeft = () => Infinity) {
-  const stripPossessive = (s) => {
-    const str = String(s).trim()
-    if (str.split(/\s+/).length > 1) return str
-    return str.replace(/[’']s$/i, '')
-  }
   const entityToString = (e) => {
     if (Array.isArray(e?.terms) && e.terms.length) {
       const parts = []

--- a/controllers/keywordParser.js
+++ b/controllers/keywordParser.js
@@ -3,21 +3,22 @@ import { toString as nlcstToString } from 'nlcst-to-string'
 import pos from 'retext-pos'
 import keywords from 'retext-keywords'
 import _ from 'lodash'
-import { capitalizeFirstLetter } from '../helpers.js'
+import { capitalizeFirstLetter, stripPossessive } from '../helpers.js'
 
 export default async function keywordParser (html, options = { maximum: 10 }) {
   const file = await retext().use(pos).use(keywords, options).process(html)
 
   const keywordsArr = file.data.keywords.map(keyword => ({
-    keyword: capitalizeFirstLetter(nlcstToString(keyword.matches[0].node)),
+    keyword: capitalizeFirstLetter(stripPossessive(nlcstToString(keyword.matches[0].node))),
     score: keyword.score
   }))
 
   const keyphrases = file.data.keyphrases.map(phrase => {
     const nodes = phrase.matches[0].nodes
     const tree = _.map(nodes)
+    const kp = stripPossessive(nlcstToString(tree, ''))
     return {
-      keyphrase: capitalizeFirstLetter(nlcstToString(tree, '')),
+      keyphrase: capitalizeFirstLetter(kp),
       score: phrase.score,
       weight: phrase.weight
     }

--- a/helpers.js
+++ b/helpers.js
@@ -77,6 +77,12 @@ export function capitalizeFirstLetter (string) {
   return string.charAt(0).toUpperCase() + string.slice(1)
 }
 
+export function stripPossessive (s) {
+  const str = String(s).trim()
+  if (str.split(/\s+/).length > 1) return str
+  return str.replace(/[’']s$/i, '')
+}
+
 export function toTitleCase (str) {
   return str.replace(/\w\S*/g, function (txt) {
     return txt.charAt(0).toUpperCase() + txt.substr(1).toLowerCase()

--- a/tests/keywordParser.test.js
+++ b/tests/keywordParser.test.js
@@ -23,3 +23,10 @@ test('keywordParser capitalizes keywords and keyphrases', async () => {
   assert.equal(res.keywords[0].keyword[0], res.keywords[0].keyword[0].toUpperCase())
   assert.equal(res.keyphrases[0].keyphrase[0], res.keyphrases[0].keyphrase[0].toUpperCase())
 })
+
+test('keywordParser strips trailing possessive from keywords and keyphrases', async () => {
+  const res = await keywordParser("Kremlin's economy is Kremlin's")
+  assert.equal(res.keywords[0].keyword, 'Kremlin')
+  assert.ok(res.keyphrases.some(p => p.keyphrase === 'Kremlin'))
+  assert.ok(res.keyphrases.some(p => p.keyphrase === "Kremlin's economy"))
+})


### PR DESCRIPTION
## Summary
- factor out `stripPossessive` helper
- normalize keywords and keyphrases by removing trailing possessive endings
- share possessive stripping logic across entity and keyword parsers

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c58927fdf08332aed900353e8528ca