### PR TITLE
fix: strip possessives from multi-word people entities

### DIFF
--- a/controllers/entityParser.js
+++ b/controllers/entityParser.js
@@ -29,11 +29,11 @@ export default function entityParser (nlpInput, pluginHints = { first: [], last:
     return null
   }
 
-  const dedupeEntities = (arr) => {
+  const dedupeEntities = (arr, stripAll = false) => {
     const out = []
     const seen = new Set()
     for (const s of arr) {
-      const str = stripPossessive(String(s || '').trim())
+      const str = stripPossessive(String(s || '').trim(), stripAll)
       if (!str) continue
       const key = normalizeEntity(str)
       if (!seen.has(key)) {
@@ -45,7 +45,7 @@ export default function entityParser (nlpInput, pluginHints = { first: [], last:
   }
 
   const result = {}
-  result.people = dedupeEntities(nlp(nlpInput).people().json().map(entityToString))
+  result.people = dedupeEntities(nlp(nlpInput).people().json().map(entityToString), true)
   const seen = new Set(result.people.map(p => normalizeEntity(p)))
   if (pluginHints.first.length && pluginHints.last.length) {
     const haystack = normalizeEntity(nlpInput)
@@ -60,7 +60,7 @@ export default function entityParser (nlpInput, pluginHints = { first: [], last:
       }
     }
   }
-  result.people = dedupeEntities(result.people)
+  result.people = dedupeEntities(result.people, true)
   if (timeLeft() >= 1000) result.places = dedupeEntities(nlp(nlpInput).places().json().map(entityToString))
   if (timeLeft() >= 900) result.orgs = dedupeEntities(nlp(nlpInput).organizations().json().map(entityToString))
   if (timeLeft() >= 800) result.topics = dedupeEntities(nlp(nlpInput).topics().json().map(entityToString))

--- a/helpers.js
+++ b/helpers.js
@@ -77,9 +77,9 @@ export function capitalizeFirstLetter (string) {
   return string.charAt(0).toUpperCase() + string.slice(1)
 }
 
-export function stripPossessive (s) {
+export function stripPossessive (s, allWords = false) {
   const str = String(s).trim()
-  if (str.split(/\s+/).length > 1) return str
+  if (!allWords && str.split(/\s+/).length > 1) return str
   return str.replace(/[’']s$/i, '')
 }
 

--- a/tests/entityParser.test.js
+++ b/tests/entityParser.test.js
@@ -26,6 +26,14 @@ test("entityParser removes trailing possessive 's", () => {
   assert(!res.orgs?.some(o => /'s$/i.test(o)))
 })
 
+test("entityParser strips possessive for multi-word people", () => {
+  const input = "Mr Trump's visit impressed Mrs May's supporters"
+  const res = entityParser(input, { first: [], last: [] }, () => 2000)
+  assert(res.people.includes('Mr Trump'))
+  assert(res.people.includes('Mrs May'))
+  assert(!res.people.some(p => /'s$/i.test(p)))
+})
+
 test("entityParser keeps possessive for multi-word entities", () => {
   const input = "The United States's economy continues to grow"
   const res = entityParser(input, { first: [], last: [] }, () => 2000)


### PR DESCRIPTION
## Summary
- allow `stripPossessive` to strip from multi-word values when requested
- normalize people entities by removing possessive endings from multi-word names
- test multi-word possessive handling for people and preserve possessives for other multi-word entities

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c58c6dd8208332ada0fe5d01d677df