### PR TITLE
Remove punctuation instead of spacing

### DIFF
--- a/helpers.js
+++ b/helpers.js
@@ -85,7 +85,7 @@ export function stripPossessive (s, allWords = false) {
 
 export function stripPunctuation (s) {
   return String(s || '')
-    .replace(/[\p{P}\p{S}]+/gu, ' ')
+    .replace(/[\p{P}\p{S}]+/gu, '')
     .replace(/\s+/g, ' ')
     .trim()
 }

--- a/tests/helpers.test.js
+++ b/tests/helpers.test.js
@@ -1,6 +1,6 @@
 import { test } from 'node:test'
 import assert from 'node:assert/strict'
-import { setDefaultOptions, capitalizeFirstLetter, toTitleCase } from '../helpers.js'
+import { setDefaultOptions, capitalizeFirstLetter, toTitleCase, stripPunctuation } from '../helpers.js'
 
 test('setDefaultOptions applies defaults', () => {
   const opts = setDefaultOptions()
@@ -40,4 +40,10 @@ test('capitalizeFirstLetter capitalizes only first character', () => {
 
 test('toTitleCase converts words to title case', () => {
   assert.equal(toTitleCase('hello world'), 'Hello World')
+})
+
+test('stripPunctuation removes punctuation without inserting spaces', () => {
+  const input = 'one.two,three!four?five-six'
+  const result = stripPunctuation(input)
+  assert.equal(result, 'onetwothreefourfivesix')
 })


### PR DESCRIPTION
## Summary
- stop inserting spaces when stripping punctuation before NLP
- test stripping punctuation doesn't insert spaces

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c595b80b708332988e5bf493bd830d