### PR TITLE
Preserve apostrophes in stripPunctuation helper

### DIFF
--- a/helpers.js
+++ b/helpers.js
@@ -85,7 +85,7 @@ export function stripPossessive (s, allWords = false) {
 
 export function stripPunctuation (s) {
   return String(s || '')
-    .replace(/[\p{P}\p{S}]+/gu, '')
+    .replace(/[^\p{L}\p{N}\s'’]+/gu, '')
     .replace(/\s+/g, ' ')
     .trim()
 }

--- a/tests/helpers.test.js
+++ b/tests/helpers.test.js
@@ -47,3 +47,9 @@ test('stripPunctuation removes punctuation without inserting spaces', () => {
   const result = stripPunctuation(input)
   assert.equal(result, 'onetwothreefourfivesix')
 })
+
+test("stripPunctuation retains apostrophes", () => {
+  const input = "Alice's adventures in Bob’s world!"
+  const result = stripPunctuation(input)
+  assert.equal(result, "Alice's adventures in Bob’s world")
+})


### PR DESCRIPTION
## Summary
- Allow stripPunctuation to keep apostrophes so possessive words stay intact
- Add test ensuring apostrophes are preserved during punctuation stripping

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c59933e8ac8332af5912143599e514