### PR TITLE
Strip possessive suffix from final entity word

### DIFF
--- a/helpers.js
+++ b/helpers.js
@@ -79,8 +79,15 @@ export function capitalizeFirstLetter (string) {
 
 export function stripPossessive (s, allWords = false) {
   const str = String(s).trim()
-  if (!allWords && str.split(/\s+/).length > 1) return str
-  return str.replace(/[’']s$/i, '')
+  if (!str) return str
+  const words = str.split(/\s+/)
+  words[words.length - 1] = words[words.length - 1].replace(/[’']s$/i, '')
+  if (allWords && words.length > 1) {
+    for (let i = 0; i < words.length - 1; i++) {
+      words[i] = words[i].replace(/[’']s$/i, '')
+    }
+  }
+  return words.join(' ')
 }
 
 export function stripPunctuation (s) {

--- a/tests/entityParser.test.js
+++ b/tests/entityParser.test.js
@@ -34,9 +34,11 @@ test("entityParser strips possessive for multi-word people", () => {
   assert(!res.people.some(p => /'s$/i.test(p)))
 })
 
-test("entityParser keeps possessive for multi-word entities", () => {
+test("entityParser strips possessive for multi-word entities", () => {
   const input = "The United States's economy continues to grow"
   const res = entityParser(input, { first: [], last: [] }, () => 2000)
-  assert(res.places.includes("United States's"))
-  assert(res.topics.includes("United States's"))
+  assert(res.places.includes('United States'))
+  assert(res.topics.includes('United States'))
+  assert(!res.places.some(p => /'s$/i.test(p)))
+  assert(!res.topics.some(t => /'s$/i.test(t)))
 })

--- a/tests/helpers.test.js
+++ b/tests/helpers.test.js
@@ -1,6 +1,6 @@
 import { test } from 'node:test'
 import assert from 'node:assert/strict'
-import { setDefaultOptions, capitalizeFirstLetter, toTitleCase, stripPunctuation } from '../helpers.js'
+import { setDefaultOptions, capitalizeFirstLetter, toTitleCase, stripPunctuation, stripPossessive } from '../helpers.js'
 
 test('setDefaultOptions applies defaults', () => {
   const opts = setDefaultOptions()
@@ -52,4 +52,13 @@ test("stripPunctuation retains apostrophes", () => {
   const input = "Alice's adventures in Bob’s world!"
   const result = stripPunctuation(input)
   assert.equal(result, "Alice's adventures in Bob’s world")
+})
+
+test("stripPossessive removes trailing 's from last word", () => {
+  assert.equal(stripPossessive("South Africa's"), 'South Africa')
+  assert.equal(stripPossessive("America's"), 'America')
+})
+
+test("stripPossessive leaves non-final possessives", () => {
+  assert.equal(stripPossessive("America's economy"), "America's economy")
 })


### PR DESCRIPTION
## Summary
- Ensure `stripPossessive` removes trailing `'s` from the last word of an entity
- Expand helper tests for `stripPossessive`
- Update entity parser tests for new possessive handling

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c59e0a94d0833282193f9fa61a4b18