### PR TITLE
fix: strip possessive suffix from places

### DIFF
--- a/helpers.js
+++ b/helpers.js
@@ -81,10 +81,14 @@ export function stripPossessive (s, allWords = false) {
   const str = String(s).trim()
   if (!str) return str
   const words = str.split(/\s+/)
-  words[words.length - 1] = words[words.length - 1].replace(/[’']s$/i, '')
+  const stripWord = (w) =>
+    w
+      .replace(/[’']s\b/i, '')
+      .replace(/[^\p{L}\p{N}]+$/u, '')
+  words[words.length - 1] = stripWord(words[words.length - 1])
   if (allWords && words.length > 1) {
     for (let i = 0; i < words.length - 1; i++) {
-      words[i] = words[i].replace(/[’']s$/i, '')
+      words[i] = stripWord(words[i])
     }
   }
   return words.join(' ')

--- a/tests/entityParser.test.js
+++ b/tests/entityParser.test.js
@@ -42,3 +42,10 @@ test("entityParser strips possessive for multi-word entities", () => {
   assert(!res.places.some(p => /'s$/i.test(p)))
   assert(!res.topics.some(t => /'s$/i.test(t)))
 })
+
+test("entityParser handles possessive places with trailing punctuation", () => {
+  const input = "He returned from New Zealand's."
+  const res = entityParser(input, { first: [], last: [] }, () => 2000)
+  assert(res.places.includes('New Zealand'))
+  assert(!res.places.some(p => /['’]s/i.test(p)))
+})

--- a/tests/helpers.test.js
+++ b/tests/helpers.test.js
@@ -62,3 +62,8 @@ test("stripPossessive removes trailing 's from last word", () => {
 test("stripPossessive leaves non-final possessives", () => {
   assert.equal(stripPossessive("America's economy"), "America's economy")
 })
+
+test("stripPossessive handles trailing punctuation", () => {
+  assert.equal(stripPossessive("New Zealand's,"), 'New Zealand')
+  assert.equal(stripPossessive("France's."), 'France')
+})


### PR DESCRIPTION
## Summary
- Strip trailing possessive suffixes even when followed by punctuation
- Test possessive stripping on helper and entity parser paths

## Testing
- `CI=1 npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c5a4aebd0c8332bdf4fdeb6042d601