### PR TITLE
Preserve line breaks in spell check for accurate line numbers

### DIFF
--- a/controllers/spellCheck.js
+++ b/controllers/spellCheck.js
@@ -11,8 +11,8 @@ export default async function spellCheck (text, options) {
   input = input.replace(/\b[\w-]+(?:\.[\w-]+)+(?:\/\S*)?/gi, ' ')
   // remove alphanumeric tokens like 123abc
   input = input.replace(/[0-9]{1,}[a-zA-Z]{1,}/gi, ' ')
-  // collapse whitespace
-  input = input.replace(/\s+/g, ' ').trim()
+  // collapse spaces but preserve line breaks for accurate line numbers
+  input = input.replace(/\r\n/g, '\n').replace(/[ \t]+/g, ' ')
 
   if (typeof options === 'undefined') {
     options = { dictionary }

--- a/tests/spellCheck.test.js
+++ b/tests/spellCheck.test.js
@@ -16,3 +16,10 @@ test('spellCheck respects options and filters URLs', async () => {
   assert.ok(res[0].offsetStart !== undefined)
   assert.ok(res[0].offsetEnd !== undefined)
 })
+
+test('spellCheck preserves line breaks for accurate line numbers', async () => {
+  const text = 'First line\nSecond lnie with error\nThird line'
+  const res = await spellCheck(text)
+  const miss = res.find(r => r.word && r.word.toLowerCase() === 'lnie')
+  assert.equal(miss.line, 2)
+})


### PR DESCRIPTION
## Summary
- keep newline characters when normalizing text for spell checking
- test that spell check reports correct line numbers

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c5cba7916c83329202ab7107ef04ea