### PR TITLE
Preserve hyphenated words in analysis

### DIFF
--- a/controllers/entityParser.js
+++ b/controllers/entityParser.js
@@ -5,7 +5,7 @@ export function normalizeEntity (w) {
   if (typeof w !== 'string') return ''
   return w
     .replace(/[’']/g, '')
-    .replace(/[^A-Za-z0-9]+/g, ' ')
+    .replace(/[^A-Za-z0-9-]+/g, ' ')
     .trim()
     .toLowerCase()
 }
@@ -14,16 +14,18 @@ export default function entityParser (nlpInput, pluginHints = { first: [], last:
   const entityToString = (e) => {
     if (Array.isArray(e?.terms) && e.terms.length) {
       const parts = []
-      for (const term of e.terms) {
+      for (let i = 0; i < e.terms.length; i++) {
+        const term = e.terms[i]
         let text = String(term.text || '').trim()
         if (!text) continue
         if (/^[’']s$/i.test(text) && parts.length) {
           parts[parts.length - 1] += "'s"
         } else {
-          parts.push(text)
+          const isHyphen = typeof term.post === 'string' && term.post.trim() === '-' && i < e.terms.length - 1
+          parts.push(isHyphen ? text + '-' : text)
         }
       }
-      return parts.join(' ').trim()
+      return parts.join(' ').replace(/- /g, '-').trim()
     }
     if (typeof e?.text === 'string') return e.text.trim()
     return null

--- a/controllers/textProcessing.js
+++ b/controllers/textProcessing.js
@@ -13,7 +13,7 @@ export function getRawText (html) {
     unorderedListItemPrefix: ''
   }
   let rawText = htmlToText(html, options)
-  rawText = nlp(rawText).normalize().out('text')
+  rawText = nlp(rawText).out('text')
   const containsUrlLike = (s) => {
     if (!s) return false
     const str = String(s)

--- a/helpers.js
+++ b/helpers.js
@@ -96,7 +96,7 @@ export function stripPossessive (s, allWords = false) {
 
 export function stripPunctuation (s) {
   return String(s || '')
-    .replace(/[^\p{L}\p{N}\s'’]+/gu, '')
+    .replace(/[^\p{L}\p{N}\s'’-]+/gu, '')
     .replace(/\s+/g, ' ')
     .trim()
 }

--- a/tests/entityParser.test.js
+++ b/tests/entityParser.test.js
@@ -49,3 +49,9 @@ test("entityParser handles possessive places with trailing punctuation", () => {
   assert(res.places.includes('New Zealand'))
   assert(!res.places.some(p => /['’]s/i.test(p)))
 })
+
+test('entityParser preserves hyphenated names', () => {
+  const input = 'Jean-Luc Picard met Jean-Luc Picard'
+  const res = entityParser(input, { first: [], last: [] }, () => 2000)
+  assert(res.people.includes('Jean-Luc Picard'))
+})

--- a/tests/helpers.test.js
+++ b/tests/helpers.test.js
@@ -42,10 +42,10 @@ test('toTitleCase converts words to title case', () => {
   assert.equal(toTitleCase('hello world'), 'Hello World')
 })
 
-test('stripPunctuation removes punctuation without inserting spaces', () => {
+test('stripPunctuation removes punctuation without inserting spaces and keeps hyphens', () => {
   const input = 'one.two,three!four?five-six'
   const result = stripPunctuation(input)
-  assert.equal(result, 'onetwothreefourfivesix')
+  assert.equal(result, 'onetwothreefourfive-six')
 })
 
 test("stripPunctuation retains apostrophes", () => {

--- a/tests/spellCheck.test.js
+++ b/tests/spellCheck.test.js
@@ -23,3 +23,8 @@ test('spellCheck preserves line breaks for accurate line numbers', async () => {
   const miss = res.find(r => r.word && r.word.toLowerCase() === 'lnie')
   assert.equal(miss.line, 2)
 })
+
+test('spellCheck retains hyphenated words', async () => {
+  const res = await spellCheck('mispelled-wurd should be flagged')
+  assert.ok(res.some(r => r.word === 'mispelled-wurd'))
+})


### PR DESCRIPTION
## Summary
- Keep hyphenated entities intact by allowing hyphens in normalization and term assembly logic.
- Avoid compromise normalization when extracting raw text so hyphens survive preprocessing.
- Permit hyphenated tokens in punctuation stripping and test spellcheck/entity parsing for hyphenated words.

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c5d04aa10483328b7f682f8247c0d9