### PR TITLE
Fix hyphenated titles being truncated

### DIFF
--- a/controllers/titleDetector.js
+++ b/controllers/titleDetector.js
@@ -12,7 +12,9 @@ function normalizeTitle(title) {
   if (!title) return null
   let t = String(title).replace(/(\r\n|\n|\r)/gm, ' ').replace(/\s+/g, ' ').trim()
   // remove common site suffixes after delimiters
-  t = t.replace(/\s*[|\-–:·»]\s*[^|\-–:·»]{2,}\s*$/u, () => '')
+  t = t
+    .replace(/\s*[|–:·»]\s*[^|–:·»-]{2,}\s*$/u, '')
+    .replace(/\s+-\s+[^|–:·»-]{2,}\s*$/u, '')
   return t.trim() || null
 }
 

--- a/tests/titleDetector.test.js
+++ b/tests/titleDetector.test.js
@@ -26,3 +26,9 @@ test('detectTitle strips site suffix with vertical bar', () => {
   const { window } = new JSDOM(html)
   assert.equal(detectTitle(window.document), 'Story')
 })
+
+test('detectTitle preserves hyphenated words', () => {
+  const html = `<head><title>Far-right London rally - Example.com</title></head><body></body>`
+  const { window } = new JSDOM(html)
+  assert.equal(detectTitle(window.document), 'Far-right London rally')
+})


### PR DESCRIPTION
## Summary
- Preserve hyphenated words when normalizing titles
- Cover hyphenated titles with a new detector test

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c5dcf3363c8332abb19176fbc73fdc