### PR TITLE
feat: add article summary

### DIFF
--- a/APIDOC.md
+++ b/APIDOC.md
@@ -27,7 +27,7 @@
 main article parser module export function
 
 **Kind**: global function  
-**Returns**: <code>Object</code> - article parser results object  
+**Returns**: <code>Object</code> - article parser results object. Includes `summary` when `options.enabled` contains `'summary'`.
 
 | Param | Type | Description |
 | --- | --- | --- |

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 ﻿# Horseman Article Parser
 
-Horseman is a focused article scraping module for the open web. It loads pages (dynamic or AMP), detects the main story body, and returns clean, structured content ready for downstream use. Alongside text and title, it includes in-article links, metadata, sentiment, keywords/keyphrases, named entities, optional spelling suggestions, site icon, and Lighthouse signals. It also copes with live blogs, applies simple per-domain tweaks (headers/cookies/goto), and uses Puppeteer + stealth to reduce blocking.
+Horseman is a focused article scraping module for the open web. It loads pages (dynamic or AMP), detects the main story body, and returns clean, structured content ready for downstream use. Alongside text and title, it includes in-article links, metadata, sentiment, keywords/keyphrases, named entities, optional summaries, optional spelling suggestions, site icon, and Lighthouse signals. It also copes with live blogs, applies simple per-domain tweaks (headers/cookies/goto), and uses Puppeteer + stealth to reduce blocking.
 
 ## Table of Contents
 
@@ -51,6 +51,7 @@ const options = {
     "entities",
     "spelling",
     "keywords",
+    "summary",
   ],
 };
 
@@ -61,6 +62,7 @@ const options = {
     const response = {
       title: article.title.text,
       excerpt: article.excerpt,
+      summary: article.summary,
       metadescription: article.meta.description.text,
       url: article.url,
       sentiment: {
@@ -196,9 +198,11 @@ var options = {
     "entities",
     "spelling",
     "keywords",
+    "summary",
   ],
 };
 ```
+Add "summary" to `options.enabled` to generate a short summary of the article text.
 
 You may pass rules for returning an articles title & contents. This is useful in a case
 where the parser is unable to return the desired title or content e.g.
@@ -317,6 +321,7 @@ const options = {
     "entities",
     "spelling",
     "keywords",
+    "summary",
   ],
   // Optional: tweak spelling output/filters
   retextspell: {

--- a/controllers/summary.js
+++ b/controllers/summary.js
@@ -1,0 +1,6 @@
+export function buildSummary (text) {
+  if (!text || typeof text !== 'string') return ''
+  const sentences = text.match(/[^.!?]+[.!?]/g)
+  if (!Array.isArray(sentences)) return text.trim()
+  return sentences.slice(0, 2).join(' ').trim()
+}

--- a/index.js
+++ b/index.js
@@ -18,6 +18,7 @@ import spellCheck from './controllers/spellCheck.js'
 import logger from './controllers/logger.js'
 import { autoDismissConsent, injectTcfApi, removeConsentArtifacts, removeAmpConsent, clearViewportObstructions, injectConsentNuke, injectConsentNukeEarly } from './controllers/consent.js'
 import { buildLiveBlogSummary } from './controllers/liveBlog.js'
+import { buildSummary } from './controllers/summary.js'
 import { getRawText, getFormattedText, getHtmlText, htmlCleaner } from './controllers/textProcessing.js'
 import { sanitizeDataUrl } from './controllers/utils.js'
 import { safeAwait, sleep } from './controllers/async.js'
@@ -1139,6 +1140,9 @@ log('analyze', 'Evaluating meta tags')
 
   // Excerpt
   article.excerpt = capitalizeFirstLetter(article.processed.text.raw.replace(/^(.{200}[^\s]*).*/, '$1'))
+  if (options.enabled.includes('summary')) {
+    article.summary = buildSummary(article.processed.text.raw)
+  }
   const cleanNlpInput = stripPunctuation(nlpInput)
   // Prepare parallel analysis tasks
   const analysisTasks = []

--- a/tests/parseArticle.test.js
+++ b/tests/parseArticle.test.js
@@ -42,7 +42,7 @@ test('parseArticle processes local HTML', { timeout: TEST_TIMEOUT }, async (t) =
   try {
     article = await parseArticle({
       url: dataUrl,
-      enabled: ['spelling'],
+      enabled: ['spelling', 'summary'],
       timeoutMs: PARSE_TIMEOUT,
       contentWaitSelectors: ['article'],
       contentWaitTimeoutMs: 1,
@@ -56,6 +56,8 @@ test('parseArticle processes local HTML', { timeout: TEST_TIMEOUT }, async (t) =
   assert.equal(article.title.text, 'Sample Story')
   assert.ok(article.links.some(l => /example\.com/.test(l.href)))
   assert.ok(article.spelling.some(s => s.word.toLowerCase().includes('missspelled')))
+  assert.equal(typeof article.summary, 'string')
+  assert.ok(article.summary.length > 0)
 })
 
 test('parseArticle captures a screenshot when enabled', { timeout: TEST_TIMEOUT }, async (t) => {


### PR DESCRIPTION
## Summary
- generate article summaries from text
- expose summary when `options.enabled` includes `"summary"`
- document summary usage and test coverage

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c5e0965dbc83328627b2a604a805db