### PR TITLE
Move summary into text and revert to first five sentences

### DIFF
--- a/APIDOC.md
+++ b/APIDOC.md
@@ -27,8 +27,8 @@
 main article parser module export function
 
 **Kind**: global function  
-**Returns**: <code>Object</code> - article parser results object. Includes a `summary` object with
-`text` and `sentences` when `options.enabled` contains `'summary'`.
+**Returns**: <code>Object</code> - article parser results object. Includes `text.summary` and
+`text.sentences` when `options.enabled` contains `'summary'`.
 
 | Param | Type | Description |
 | --- | --- | --- |

--- a/README.md
+++ b/README.md
@@ -62,8 +62,6 @@ const options = {
     const response = {
       title: article.title.text,
       excerpt: article.excerpt,
-      summary: article.summary.text,
-      sentences: article.summary.sentences,
       metadescription: article.meta.description.text,
       url: article.url,
       sentiment: {
@@ -79,6 +77,8 @@ const options = {
         raw: article.processed.text.raw,
         formatted: article.processed.text.formatted,
         html: article.processed.text.html,
+        summary: article.processed.text.summary,
+        sentences: article.processed.text.sentences,
       },
       spelling: article.spelling,
       meta: article.meta,
@@ -204,7 +204,7 @@ var options = {
 };
 ```
 Add "summary" to `options.enabled` to generate a short summary of the article text. The result
-includes `summary.text` and a `summary.sentences` array containing the top-ranked sentences.
+includes `text.summary` and a `text.sentences` array containing the first five sentences.
 
 You may pass rules for returning an articles title & contents. This is useful in a case
 where the parser is unable to return the desired title or content e.g.

--- a/controllers/summary.js
+++ b/controllers/summary.js
@@ -1,16 +1,6 @@
-import textrankPkg from 'textrank'
-
-const { TextRank } = textrankPkg
-
 export function buildSummary (text) {
   if (!text || typeof text !== 'string') return { text: '', sentences: [] }
-  try {
-    const ranked = new TextRank(text, { extractAmount: 5, summaryType: 'array' })
-    const sentences = Array.isArray(ranked.summarizedArticle) ? ranked.summarizedArticle : []
-    return { text: sentences.join(' ').trim(), sentences }
-  } catch {
-    const sentences = text.match(/[^.!?]+[.!?]/g) || [text]
-    const top = sentences.slice(0, 5)
-    return { text: top.join(' ').trim(), sentences: top }
-  }
+  const sentences = text.match(/[^.!?]+[.!?]/g) || [text]
+  const top = sentences.slice(0, 5).map(s => s.trim())
+  return { text: top.join(' ').trim(), sentences: top }
 }

--- a/index.js
+++ b/index.js
@@ -1141,7 +1141,9 @@ log('analyze', 'Evaluating meta tags')
   // Excerpt
   article.excerpt = capitalizeFirstLetter(article.processed.text.raw.replace(/^(.{200}[^\s]*).*/, '$1'))
   if (options.enabled.includes('summary')) {
-    article.summary = buildSummary(article.processed.text.raw)
+    const { text: summaryText, sentences } = buildSummary(article.processed.text.raw)
+    article.processed.text.summary = summaryText
+    article.processed.text.sentences = sentences
   }
   const cleanNlpInput = stripPunctuation(nlpInput)
   // Prepare parallel analysis tasks

--- a/package-lock.json
+++ b/package-lock.json
@@ -29,7 +29,6 @@
         "retext-pos": "^5.0.0",
         "retext-spell": "^6.1.0",
         "sentiment": "^5.0.1",
-        "textrank": "^1.0.5",
         "undici": "^7.15.0"
       },
       "devDependencies": {
@@ -7177,12 +7176,6 @@
       "dependencies": {
         "b4a": "^1.6.4"
       }
-    },
-    "node_modules/textrank": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/textrank/-/textrank-1.0.5.tgz",
-      "integrity": "sha512-6dFKbvrBoX5Co7BPkBGmx53aIkpW7/uT3FHuXJMWUG/3IfmTfiXnli3S1HPl7Xl2/6Q9PB/ObysgVQKbtj5iLg==",
-      "license": "ISC"
     },
     "node_modules/third-party-web": {
       "version": "0.27.0",

--- a/package.json
+++ b/package.json
@@ -49,7 +49,6 @@
     "retext-pos": "^5.0.0",
     "retext-spell": "^6.1.0",
     "sentiment": "^5.0.1",
-    "textrank": "^1.0.5",
     "undici": "^7.15.0"
   },
   "devDependencies": {

--- a/scripts/single-sample-run.js
+++ b/scripts/single-sample-run.js
@@ -87,8 +87,6 @@ const __dirname = path.dirname(fileURLToPath(import.meta.url))
       bodySelector: article.bodySelector,
       bodyXPath: article.bodyXPath,
       excerpt: article.excerpt,
-      summary: article.summary.text,
-      sentences: article.summary.sentences,
       metadescription: article.meta.description.text,
       url: article.url,
       siteicon: article.siteicon,
@@ -102,7 +100,9 @@ const __dirname = path.dirname(fileURLToPath(import.meta.url))
       text: {
         raw: article.processed.text.raw,
         formatted: article.processed.text.formatted,
-        html: article.processed.text.html
+        html: article.processed.text.html,
+        summary: article.processed.text.summary,
+        sentences: article.processed.text.sentences
       },
       spelling: article.spelling,
       meta: article.meta,

--- a/tests/parseArticle.test.js
+++ b/tests/parseArticle.test.js
@@ -56,10 +56,10 @@ test('parseArticle processes local HTML', { timeout: TEST_TIMEOUT }, async (t) =
   assert.equal(article.title.text, 'Sample Story')
   assert.ok(article.links.some(l => /example\.com/.test(l.href)))
   assert.ok(article.spelling.some(s => s.word.toLowerCase().includes('missspelled')))
-  assert.equal(typeof article.summary.text, 'string')
-  assert.ok(article.summary.text.length > 0)
-  assert.ok(Array.isArray(article.summary.sentences))
-  assert.ok(article.summary.sentences.length > 0)
+  assert.equal(typeof article.processed.text.summary, 'string')
+  assert.ok(article.processed.text.summary.length > 0)
+  assert.ok(Array.isArray(article.processed.text.sentences))
+  assert.ok(article.processed.text.sentences.length > 0)
 })
 
 test('parseArticle captures a screenshot when enabled', { timeout: TEST_TIMEOUT }, async (t) => {


### PR DESCRIPTION
## Summary
- Return article summary as the first five sentences and drop TextRank dependency
- Store summary text and sentence list under `processed.text`
- Update docs, scripts and tests for new `text.summary` and `text.sentences` structure

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c5e9e9216c833286e352d80791a320