### PR TITLE
Add readability counts

### DIFF
--- a/APIDOC.md
+++ b/APIDOC.md
@@ -29,7 +29,7 @@ main article parser module export function
 **Kind**: global function  
 **Returns**: <code>Object</code> - article parser results object. Includes `text.summary` and
 `text.sentences` when `options.enabled` contains `'summary'`. Also exposes
-`language` with ISO-639-1 and ISO-639-3 codes when detection succeeds. Includes `readability` with readability scores and estimated reading time when `options.enabled` contains 'readability'.
+`language` with ISO-639-1 and ISO-639-3 codes when detection succeeds. Includes `readability` with estimated reading time and basic text statistics when `options.enabled` contains 'readability'.
 
 | Param | Type | Description |
 | --- | --- | --- |

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 ﻿# Horseman Article Parser
 
-Horseman is a focused article scraping module for the open web. It loads pages (dynamic or AMP), detects the main story body, and returns clean, structured content ready for downstream use. Alongside text and title, it includes in-article links, metadata, sentiment, keywords/keyphrases, named entities, optional summaries, optional spelling suggestions, readability metrics, site icon, and Lighthouse signals. It also copes with live blogs, applies simple per-domain tweaks (headers/cookies/goto), and uses Puppeteer + stealth to reduce blocking. The parser now detects the article language and exposes ISO codes, with best-effort support for non-English content (features may fall back to English dictionaries when specific resources are missing).
+Horseman is a focused article scraping module for the open web. It loads pages (dynamic or AMP), detects the main story body, and returns clean, structured content ready for downstream use. Alongside text and title, it includes in-article links, metadata, sentiment, keywords/keyphrases, named entities, optional summaries, optional spelling suggestions, readability metrics and basic counts (characters, words, sentences, paragraphs), site icon, and Lighthouse signals. It also copes with live blogs, applies simple per-domain tweaks (headers/cookies/goto), and uses Puppeteer + stealth to reduce blocking. The parser now detects the article language and exposes ISO codes, with best-effort support for non-English content (features may fall back to English dictionaries when specific resources are missing).
 
 ## Table of Contents
 
@@ -75,7 +75,13 @@ const options = {
       orgs: article.orgs,
       places: article.places,
       language: article.language,
-      readability: article.readability,
+      readability: {
+        readingTime: article.readability.readingTime,
+        characters: article.readability.characters,
+        words: article.readability.words,
+        sentences: article.readability.sentences,
+        paragraphs: article.readability.paragraphs,
+      },
       text: {
         raw: article.processed.text.raw,
         formatted: article.processed.text.formatted,
@@ -210,7 +216,7 @@ var options = {
 Add "summary" to `options.enabled` to generate a short summary of the article text. The result
 includes `text.summary` and a `text.sentences` array containing the first five sentences.
 
-Add "readability" to `options.enabled` to evaluate readability and estimate reading time. The result is available as `article.readability` with `scores` and `readingTime` (seconds).
+Add "readability" to `options.enabled` to evaluate readability, estimate reading time, and gather basic text statistics. The result is available as `article.readability` with `readingTime` (seconds), `characters`, `words`, `sentences`, and `paragraphs`.
 
 You may pass rules for returning an articles title & contents. This is useful in a case
 where the parser is unable to return the desired title or content e.g.

--- a/controllers/readability.js
+++ b/controllers/readability.js
@@ -1,29 +1,18 @@
-import { retext } from 'retext'
-import readability from 'retext-readability'
-
 /**
- * Evaluate readability of text and estimate reading time.
- * Returns an array of readability warnings with algorithm counts
- * and an estimated reading time in seconds (assuming ~200 wpm).
+ * Evaluate basic readability statistics and estimate reading time.
+ * Returns an estimated reading time in seconds (assuming ~200 wpm) and
+ * basic document statistics (characters, words, sentences, paragraphs).
  *
  * @param {string} text raw text input
- * @returns {{scores: Array<{sentence: string, algorithms: number, total: number}>, readingTime: number}}
+ * @returns {{readingTime: number, characters: number, words: number, sentences: number, paragraphs: number}}
  */
 export default async function checkReadability (text) {
-  if (!text || typeof text !== 'string') return { scores: [], readingTime: 0 }
-  const file = await retext().use(readability).process(text)
-  const words = text.trim().split(/\s+/).filter(Boolean).length
+  if (!text || typeof text !== 'string') return { readingTime: 0, characters: 0, words: 0, sentences: 0, paragraphs: 0 }
+  const trimmed = text.trim()
+  const characters = trimmed.length
+  const words = trimmed.split(/\s+/).filter(Boolean).length
+  const sentences = trimmed.split(/[.!?]+/).filter(s => s.trim().length > 0).length
+  const paragraphs = trimmed.split(/\n{2,}/).filter(p => p.trim().length > 0).length
   const readingTime = Math.round((words / 200) * 60)
-  const scores = file.messages.map(m => {
-    const reason = String(m.reason || '')
-    const match = reason.match(/according to (\d+) out of (\d+) algorithms/) || reason.match(/according to all (\d+) algorithms/)
-    let algorithms = 0
-    let total = 0
-    if (match) {
-      if (match[2]) { algorithms = Number(match[1]); total = Number(match[2]) }
-      else { algorithms = Number(match[1]); total = Number(match[1]) }
-    }
-    return { sentence: m.actual, algorithms, total }
-  })
-  return { scores, readingTime }
+  return { readingTime, characters, words, sentences, paragraphs }
 }

--- a/index.js
+++ b/index.js
@@ -1184,7 +1184,7 @@ log('analyze', 'Evaluating meta tags')
     try {
       log('analyze', 'Evaluating readability')
       article.readability = await checkReadability(article.processed.text.raw)
-      try { log('analyze', 'Readability evaluated', { hard: Array.isArray(article.readability.scores) ? article.readability.scores.length : 0, reading_time: article.readability.readingTime }) } catch {}
+      try { log('analyze', 'Readability evaluated', { reading_time: article.readability.readingTime }) } catch {}
     } catch {}
   }
 

--- a/scripts/single-sample-run.js
+++ b/scripts/single-sample-run.js
@@ -92,7 +92,13 @@ const __dirname = path.dirname(fileURLToPath(import.meta.url))
       siteicon: article.siteicon,
       screenshot: article.screenshot,
       sentiment: { score: article.sentiment.score, comparative: article.sentiment.comparative },
-      readability: article.readability,
+      readability: {
+        readingTime: article.readability.readingTime,
+        characters: article.readability.characters,
+        words: article.readability.words,
+        sentences: article.readability.sentences,
+        paragraphs: article.readability.paragraphs
+      },
       keyphrases: article.processed.keyphrases,
       keywords: article.processed.keywords,
       people: article.people,

--- a/tests/readability.test.js
+++ b/tests/readability.test.js
@@ -1,0 +1,13 @@
+import { test } from 'node:test'
+import assert from 'node:assert/strict'
+import checkReadability from '../controllers/readability.js'
+
+test('checkReadability returns basic counts', async () => {
+  const text = 'First sentence. Second sentence!\n\nNew paragraph here.'
+  const res = await checkReadability(text)
+  assert.equal('scores' in res, false)
+  assert.equal(res.characters, text.trim().length)
+  assert.equal(res.words, 7)
+  assert.equal(res.sentences, 3)
+  assert.equal(res.paragraphs, 2)
+})


### PR DESCRIPTION
## Summary
- drop readability score array and return only basic counts and reading time
- remove score field from single-sample-run output and documentation
- assert readability output omits scores

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c5faef39ac83329b4e5c6bb7aada37