### PR TITLE
Fix paragraph counting in readability metrics

### DIFF
--- a/controllers/readability.js
+++ b/controllers/readability.js
@@ -12,7 +12,7 @@ export default async function checkReadability (text) {
   const characters = trimmed.length
   const words = trimmed.split(/\s+/).filter(Boolean).length
   const sentences = trimmed.split(/[.!?]+/).filter(s => s.trim().length > 0).length
-  const paragraphs = trimmed.split(/\n{2,}/).filter(p => p.trim().length > 0).length
+  const paragraphs = trimmed.split(/\r?\n+/).filter(p => p.trim().length > 0).length
   const readingTime = Math.round((words / 200) * 60)
   return { readingTime, characters, words, sentences, paragraphs }
 }

--- a/tests/readability.test.js
+++ b/tests/readability.test.js
@@ -11,3 +11,9 @@ test('checkReadability returns basic counts', async () => {
   assert.equal(res.sentences, 3)
   assert.equal(res.paragraphs, 2)
 })
+
+test('checkReadability counts single newline paragraphs', async () => {
+  const text = 'First paragraph.\nSecond paragraph.'
+  const res = await checkReadability(text)
+  assert.equal(res.paragraphs, 2)
+})


### PR DESCRIPTION
## Summary
- handle single or multiple newlines when counting readability paragraphs
- test paragraph counting for single newline separated text

## Testing
- `node --test tests/readability.test.js`
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c60002bc6c8332868ba0bb1e519d85