### PR TITLE
Fix readability paragraph count

### DIFF
--- a/index.js
+++ b/index.js
@@ -1183,7 +1183,7 @@ log('analyze', 'Evaluating meta tags')
   if (options.enabled.includes('readability')) {
     try {
       log('analyze', 'Evaluating readability')
-      article.readability = await checkReadability(article.processed.text.raw)
+      article.readability = await checkReadability(article.processed.text.formatted)
       try { log('analyze', 'Readability evaluated', { reading_time: article.readability.readingTime }) } catch {}
     } catch {}
   }

--- a/tests/parseArticle.test.js
+++ b/tests/parseArticle.test.js
@@ -42,7 +42,7 @@ test('parseArticle processes local HTML', { timeout: TEST_TIMEOUT }, async (t) =
   try {
     article = await parseArticle({
       url: dataUrl,
-      enabled: ['spelling', 'summary'],
+      enabled: ['spelling', 'summary', 'readability'],
       timeoutMs: PARSE_TIMEOUT,
       contentWaitSelectors: ['article'],
       contentWaitTimeoutMs: 1,
@@ -60,6 +60,7 @@ test('parseArticle processes local HTML', { timeout: TEST_TIMEOUT }, async (t) =
   assert.ok(article.processed.text.summary.length > 0)
   assert.ok(Array.isArray(article.processed.text.sentences))
   assert.ok(article.processed.text.sentences.length > 0)
+  assert.ok(article.readability.paragraphs > 1)
 })
 
 test('parseArticle captures a screenshot when enabled', { timeout: TEST_TIMEOUT }, async (t) => {


### PR DESCRIPTION
## Summary
- ensure readability statistics use formatted text so paragraph counts aren't lost when whitespace is stripped
- test parseArticle integration for paragraph count when readability enabled

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c601ca2b0c8332ab591abc09baa8af