### PR TITLE
Sanitize article text before entity and keyword analysis

### DIFF
--- a/controllers/textProcessing.js
+++ b/controllers/textProcessing.js
@@ -1,6 +1,132 @@
 import cleaner from 'clean-html'
 import { htmlToText } from 'html-to-text'
 import nlp from 'compromise'
+import { JSDOM } from 'jsdom'
+
+const CTA_ATTR_KEYWORDS = [
+  'newsletter', 'subscribe', 'subscription', 'signup', 'sign-up', 'sign_up', 'calltoaction', 'call-to-action', 'cta',
+  'promo', 'promotion', 'promoted', 'advert', 'ads', 'adunit', 'ad-unit', 'ad_slot', 'sponsor', 'sponsored', 'sponsorship',
+  'related', 'recirc', 'recirculation', 'readmore', 'read-more', 'readnext', 'read-next', 'mostread', 'most-read',
+  'mostpopular', 'most-popular', 'popular', 'trending', 'recommended', 'recommendation', 'outbrain', 'taboola',
+  'share', 'social', 'follow', 'followus', 'follow-us', 'follow_btn', 'email-signup', 'email_signup', 'optin', 'opt-in',
+  'marketing', 'commerce', 'partner-link', 'affiliate'
+]
+
+const CTA_TEXT_KEYWORDS = [
+  'sign up', 'sign me up', 'sign in', 'subscribe', 'subscription', 'newsletter', 'call to action', 'cta', 'join now',
+  'join today', 'join us', 'get started', 'get the latest', 'get updates', 'get our', 'read more', 'read next', 'watch now',
+  'listen now', 'learn more', 'share this', 'share on', 'follow us', 'follow on', 'follow the', 'donate', 'support us',
+  'support our', 'buy now', 'shop now', 'order now', 'start trial', 'start your trial', 'start free trial', 'start a free trial',
+  'log in', 'log on', 'login', 'register', 'register now', 'register today', 'advertisement', 'advertiser', 'sponsored content',
+  'paid post', 'promo code'
+]
+
+const ALWAYS_REMOVE_TAGS = new Set(['NAV', 'FOOTER'])
+
+const sentenceSplitter = /[.!?]+/g
+
+function normalizeWhitespace (text) {
+  return String(text || '')
+    .replace(/\s+/g, ' ')
+    .trim()
+}
+
+function getMeaningfulText (node) {
+  if (!node || typeof node.textContent !== 'string') return ''
+  const text = normalizeWhitespace(node.textContent)
+  if (!text) return ''
+  if (!/[\p{L}\p{N}]/u.test(text)) return ''
+  return text
+}
+
+function hasMeaningfulText (node) {
+  return getMeaningfulText(node).length > 0
+}
+
+function nodeDepth (node) {
+  let depth = 0
+  let current = node
+  while (current && current.parentElement) {
+    depth += 1
+    current = current.parentElement
+  }
+  return depth
+}
+
+function collectAttributeSignals (node) {
+  const signals = []
+  try {
+    if (typeof node.id === 'string' && node.id) signals.push(node.id)
+  } catch {}
+  try {
+    if (node.classList && node.classList.length) {
+      signals.push(...Array.from(node.classList).filter(Boolean))
+    } else if (typeof node.className === 'string' && node.className) {
+      signals.push(node.className)
+    }
+  } catch {}
+  try {
+    if (typeof node.getAttributeNames === 'function') {
+      const names = node.getAttributeNames()
+      for (const name of names) {
+        if (!name) continue
+        if (name === 'id' || name === 'class' || name === 'style') continue
+        if (!/^data-|^aria-|^role$/i.test(name) && !/name$/i.test(name)) continue
+        const value = node.getAttribute(name)
+        if (typeof value === 'string' && value.trim()) signals.push(value)
+      }
+    }
+  } catch {}
+  return signals.join(' ').toLowerCase()
+}
+
+function shouldRemoveByAttributes (node, textLen) {
+  if (!node || !node.parentNode) return false
+  const haystack = collectAttributeSignals(node)
+  if (!haystack) return false
+  if (textLen > 800) return false
+  for (const keyword of CTA_ATTR_KEYWORDS) {
+    if (haystack.includes(keyword)) return true
+  }
+  return false
+}
+
+function anchorTextLength (node) {
+  if (!node || typeof node.querySelectorAll !== 'function') return 0
+  let total = 0
+  try {
+    const anchors = node.querySelectorAll('a')
+    for (const anchor of anchors) {
+      total += getMeaningfulText(anchor).length
+    }
+  } catch {}
+  return total
+}
+
+function countSentences (text) {
+  if (!text) return 0
+  const pieces = String(text).split(sentenceSplitter)
+  return pieces.filter(part => normalizeWhitespace(part).length > 0).length
+}
+
+function shouldRemoveByText (node, text) {
+  if (!text) return false
+  const textLen = text.length
+  const lower = text.toLowerCase()
+  if (textLen <= 400) {
+    for (const keyword of CTA_TEXT_KEYWORDS) {
+      if (lower.includes(keyword)) {
+        if (countSentences(text) <= 2) return true
+        break
+      }
+    }
+  }
+  if (textLen <= 600) {
+    const anchorLen = anchorTextLength(node)
+    if (anchorLen > 0 && anchorLen >= textLen * 0.9) return true
+  }
+  return false
+}
 
 export function getRawText (html) {
   const options = {
@@ -76,4 +202,95 @@ export function htmlCleaner (html, options = {
       resolve(out)
     })
   })
+}
+
+export function stripNonArticleElements (html) {
+  if (typeof html !== 'string' || !html.trim()) return typeof html === 'string' ? html : ''
+  let dom
+  try {
+    dom = new JSDOM(`<body>${html}</body>`)
+  } catch {
+    try {
+      dom = new JSDOM(html)
+    } catch {
+      return html
+    }
+  }
+  const { document, NodeFilter } = dom.window
+  const root = document.body || document.documentElement
+  if (!root) {
+    dom.window.close()
+    return html
+  }
+
+  const removeNode = (node) => {
+    if (node && node.parentNode) {
+      node.parentNode.removeChild(node)
+    }
+  }
+
+  const staticSelectors = [
+    'script', 'style', 'noscript', 'template', 'iframe', 'canvas', 'svg', 'picture', 'source',
+    'video', 'audio', 'track', 'map', 'object', 'embed'
+  ]
+  for (const sel of staticSelectors) {
+    for (const node of Array.from(root.querySelectorAll(sel))) removeNode(node)
+  }
+
+  const interactiveSelectors = [
+    'form', 'button', 'input', 'select', 'textarea', 'label', 'details', 'summary', 'dialog'
+  ]
+  for (const sel of interactiveSelectors) {
+    for (const node of Array.from(root.querySelectorAll(sel))) removeNode(node)
+  }
+
+  for (const node of Array.from(root.querySelectorAll('[role="button"], [role="link"], [role="menu"], [role="dialog"]'))) {
+    removeNode(node)
+  }
+
+  for (const anchor of Array.from(root.querySelectorAll('a'))) {
+    if (!hasMeaningfulText(anchor)) removeNode(anchor)
+  }
+
+  for (const li of Array.from(root.querySelectorAll('li'))) {
+    if (!hasMeaningfulText(li)) removeNode(li)
+  }
+
+  for (const figure of Array.from(root.querySelectorAll('figure'))) {
+    const caption = figure.querySelector('figcaption')
+    if (caption && !hasMeaningfulText(caption)) removeNode(caption)
+    if (!hasMeaningfulText(figure)) removeNode(figure)
+  }
+
+  const nodes = []
+  const walker = document.createTreeWalker(root, NodeFilter?.SHOW_ELEMENT || 1)
+  while (walker.nextNode()) nodes.push(walker.currentNode)
+  nodes.sort((a, b) => nodeDepth(b) - nodeDepth(a))
+
+  for (const node of nodes) {
+    if (!node || !node.parentNode) continue
+    if (node === root) continue
+    const tag = node.tagName
+    if (ALWAYS_REMOVE_TAGS.has(tag)) {
+      removeNode(node)
+      continue
+    }
+    const text = getMeaningfulText(node)
+    if (!text) {
+      removeNode(node)
+      continue
+    }
+    const textLen = text.length
+    if (shouldRemoveByAttributes(node, textLen)) {
+      removeNode(node)
+      continue
+    }
+    if (shouldRemoveByText(node, text)) {
+      removeNode(node)
+    }
+  }
+
+  const cleaned = root.innerHTML
+  dom.window.close()
+  return cleaned
 }

--- a/index.js
+++ b/index.js
@@ -19,7 +19,7 @@ import logger from './controllers/logger.js'
 import { autoDismissConsent, injectTcfApi, removeConsentArtifacts, removeAmpConsent, clearViewportObstructions, injectConsentNuke, injectConsentNukeEarly } from './controllers/consent.js'
 import { buildLiveBlogSummary } from './controllers/liveBlog.js'
 import { buildSummary } from './controllers/summary.js'
-import { getRawText, getFormattedText, getHtmlText, htmlCleaner } from './controllers/textProcessing.js'
+import { getRawText, getFormattedText, getHtmlText, htmlCleaner, stripNonArticleElements } from './controllers/textProcessing.js'
 import { sanitizeDataUrl } from './controllers/utils.js'
 import { safeAwait, sleep } from './controllers/async.js'
 import { timeLeftFactory, waitForFrameStability, navigateWithFallback } from './controllers/navigation.js'
@@ -980,11 +980,22 @@ log('analyze', 'Evaluating meta tags')
 
   // Raw Text (text prepared for keyword analysis & named entity recongnition)
   article.processed.text.raw = await getRawText(article.processed.html)
+  let analysisInput = ''
+  try {
+    const sanitizedHtml = stripNonArticleElements(article.processed.html)
+    analysisInput = await getRawText(sanitizedHtml)
+  } catch {
+    analysisInput = ''
+  }
   const capForNlp = 20000
   let nlpInput = article.processed.text.raw
+  if (!analysisInput) analysisInput = nlpInput
   if (nlpInput.length > capForNlp) {
     nlpInput = nlpInput.slice(0, capForNlp)
     log('nlp', 'cap input', { chars: capForNlp })
+  }
+  if (analysisInput.length > capForNlp) {
+    analysisInput = analysisInput.slice(0, capForNlp)
   }
 
   try {
@@ -1174,7 +1185,7 @@ log('analyze', 'Evaluating meta tags')
     article.processed.text.summary = summaryText
     article.processed.text.sentences = sentences
   }
-  const cleanNlpInput = stripPunctuation(nlpInput)
+  const cleanAnalysisInput = stripPunctuation(analysisInput)
   // Prepare parallel analysis tasks
   const analysisTasks = []
 
@@ -1210,7 +1221,7 @@ log('analyze', 'Evaluating meta tags')
       try {
         log('analyze', 'Extracting named entities')
         if (timeLeft() < 1200) { log('analyze', 'Skipping NER due to low budget'); return }
-        const entities = entityParser(cleanNlpInput, pluginHints, timeLeft)
+        const entities = entityParser(cleanAnalysisInput, pluginHints, timeLeft)
         Object.assign(article, entities)
         try {
           const pc = Array.isArray(article.people) ? article.people.length : 0
@@ -1286,7 +1297,7 @@ log('analyze', 'Evaluating meta tags')
       if (timeLeft() > 500) jobs.push(keywordParser(article.title.text, options.retextkeywords).then(r => Object.assign(article.title, r)).catch(() => {}))
       if (timeLeft() > 500) jobs.push(keywordParser(article.meta.description.text, options.retextkeywords).then(r => Object.assign(article.meta.description, r)).catch(() => {}))
       if (timeLeft() > 600) jobs.push(
-          keywordParser(cleanNlpInput, options.retextkeywords).then(kw => {
+          keywordParser(cleanAnalysisInput, options.retextkeywords).then(kw => {
             Object.assign(article.processed, kw)
             try {
               const kc = Array.isArray(kw.keywords) ? kw.keywords.length : 0

--- a/tests/textProcessing.test.js
+++ b/tests/textProcessing.test.js
@@ -1,7 +1,7 @@
 import { test } from 'node:test'
 import assert from 'node:assert/strict'
 import fs from 'fs'
-import { getRawText, getFormattedText, getHtmlText, htmlCleaner } from '../controllers/textProcessing.js'
+import { getRawText, getFormattedText, getHtmlText, htmlCleaner, stripNonArticleElements } from '../controllers/textProcessing.js'
 
 test('getRawText strips URLs', () => {
   const html = '<p>Visit <a href="http://example.com">http://example.com</a></p>'
@@ -36,4 +36,51 @@ test('htmlCleaner resolves with sanitized html', async () => {
   const out = await htmlCleaner('&nbsp;<span>hi</span>')
   assert.equal(typeof out, 'string')
   assert.ok(out.includes('hi'))
+})
+
+test('stripNonArticleElements removes empty anchors and retains body text', () => {
+  const html = '<div><a href="/story"><img src="pic.jpg" alt="" /></a><p>Actual story text.</p></div>'
+  const sanitized = stripNonArticleElements(html)
+  assert.ok(sanitized.includes('Actual story text'))
+  assert.ok(!sanitized.includes('<a'))
+})
+
+test('stripNonArticleElements removes newsletter and CTA containers', () => {
+  const html = `
+    <div class="newsletter-signup">
+      <form>
+        <label>Sign up for our newsletter</label>
+        <input type="email" />
+      </form>
+      <p>Subscribe for updates.</p>
+    </div>
+    <p>Article paragraph with context.</p>
+  `
+  const sanitized = stripNonArticleElements(html)
+  assert.ok(sanitized.includes('Article paragraph with context'))
+  assert.ok(!sanitized.includes('Sign up for our newsletter'))
+  assert.ok(!sanitized.includes('newsletter-signup'))
+})
+
+test('stripNonArticleElements keeps text-based lists', () => {
+  const html = '<article><ul><li>First important fact</li><li>Second detail</li></ul></article>'
+  const sanitized = stripNonArticleElements(html)
+  assert.ok(sanitized.includes('<ul'))
+  assert.ok(sanitized.includes('First important fact'))
+})
+
+test('stripNonArticleElements drops recirculation link lists', () => {
+  const html = `
+    <div class="related">
+      <ul>
+        <li><a href="/one">Story One</a></li>
+        <li><a href="/two">Story Two</a></li>
+      </ul>
+    </div>
+    <p>Main body continues.</p>
+  `
+  const sanitized = stripNonArticleElements(html)
+  assert.ok(sanitized.includes('Main body continues'))
+  assert.ok(!sanitized.includes('Story One'))
+  assert.ok(!sanitized.includes('Story Two'))
 })


### PR DESCRIPTION
## Summary
- add a DOM-driven sanitizer that prunes non-textual and CTA-heavy elements before NLP analysis
- feed the sanitized article text into entity and keyword extraction without affecting other features
- extend text processing tests to cover the new sanitizer behaviour

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68c86a6ece488332960b6f5070af2c35