### PR TITLE
Prevent colon suffix removal from truncating titles

### DIFF
--- a/controllers/titleDetector.js
+++ b/controllers/titleDetector.js
@@ -13,7 +13,7 @@ function normalizeTitle(title) {
   let t = String(title).replace(/(\r\n|\n|\r)/gm, ' ').replace(/\s+/g, ' ').trim()
   // remove common site suffixes after delimiters
   t = t
-    .replace(/\s*[|–:·»]\s*[^|–:·»-]{2,}\s*$/u, '')
+    .replace(/\s*[|–·»]\s*[^|–:·»-]{2,}\s*$/u, '')
     .replace(/\s+-\s+[^|–:·»-]{2,}\s*$/u, '')
   return t.trim() || null
 }

--- a/tests/titleDetector.test.js
+++ b/tests/titleDetector.test.js
@@ -32,3 +32,10 @@ test('detectTitle preserves hyphenated words', () => {
   const { window } = new JSDOM(html)
   assert.equal(detectTitle(window.document), 'Far-right London rally')
 })
+
+test('detectTitle keeps subtitles separated by colon', () => {
+  const fullTitle = 'PM: I would never have appointed Mandelson had I known full Epstein links'
+  const html = `<head><title>${fullTitle}</title></head><body></body>`
+  const { window } = new JSDOM(html)
+  assert.equal(detectTitle(window.document), fullTitle)
+})


### PR DESCRIPTION
## Summary
- adjust title normalization to stop trimming colon-delimited subtitles
- add a regression test ensuring colon-separated titles are preserved

## Testing
- npm test *(fails: puppeteer cannot launch due to missing libatk-1.0)*

------
https://chatgpt.com/codex/tasks/task_e_68c87b897bec8332977a7865cb7193fb