### PR TITLE
Improve fragmented article container promotion

### DIFF
--- a/tests/contentDetector.test.js
+++ b/tests/contentDetector.test.js
@@ -27,3 +27,27 @@ test('detectContent strips boilerplate from blog fixture', () => {
   assert.match(res.html, /Blog Title/)
   assert.doesNotMatch(res.html, /Home/)
 })
+
+test('detectContent promotes the direct parent for fragmented articles', () => {
+  const part1 = 'First fragment text with enough content to meet the minimum length requirement. '.repeat(6)
+  const part2 = 'Second fragment ensures aggregated content meets heuristics properly. '.repeat(6)
+  const html = `
+    <html>
+      <body>
+        <article id="story">
+          <header><h1>Fragmented Story</h1></header>
+          <div id="article-body">
+            <div class="segment"><p>${part1}</p></div>
+            <div class="segment"><p>${part2}</p></div>
+          </div>
+          <footer><p>Footer details</p></footer>
+        </article>
+      </body>
+    </html>
+  `
+  const { window } = new JSDOM(html)
+  const res = detectContent(window.document)
+  assert.equal(res.selector, '#article-body')
+  assert.match(res.html, /First fragment text/)
+  assert.match(res.html, /Second fragment ensures aggregated content/)
+})


### PR DESCRIPTION
## Summary
- refactor the fragmentation heuristics into a reusable helper and reuse it for both detection paths
- promote fragmented content to the closest ancestor that contains all fragments instead of jumping to higher level containers
- add a regression test that covers fragmented article bodies and ensures the wrapper div is selected

## Testing
- node --test tests/contentDetector.test.js

------
https://chatgpt.com/codex/tasks/task_e_68c8895153b48332ba7339035b88442a