### PR TITLE
Enhance entity detection and inline spacing

### DIFF
--- a/README.md
+++ b/README.md
@@ -356,6 +356,31 @@ By tagging new words as `FirstName` and `LastName`, the parser records fallback 
 
 Check out the compromise plugin [docs](https://observablehq.com/@spencermountain/compromise-plugins) for more info.
 
+#### Extended name hints and secondary NER sources
+
+`loadNlpPlugins` also accepts additional hint buckets for middle names and suffixes. You can provide them directly via `options.nlp.hints` or through a Compromise plugin using `MiddleName`/`Suffix` tags. These extra hints help prevent false splits in names that include common middle initials or honorifics.
+
+```js
+const options = {
+  nlp: {
+    hints: {
+      first: ['José', 'Ana'],
+      middle: ['Luis', 'María'],
+      last: ['Rodríguez', 'López'],
+      suffix: ['Jr']
+    },
+    secondary: {
+      endpoint: 'https://ner.yourservice.example/people',
+      method: 'POST',
+      timeoutMs: 1500,
+      minConfidence: 0.65
+    }
+  }
+}
+```
+
+When `secondary` is configured the parser will send the article text to that endpoint (default payload `{ text: "…" }`) and merge any `PERSON` entities it returns with the Compromise results. Responses that include a simple `people` array or spaCy-style `ents` collections are supported. If the service is unreachable or errors, the parser automatically falls back to Compromise-only detection.
+
 ### Content Detection
 
 The detector is always enabled and uses a structured-data-first strategy, falling back to heuristic scoring:

--- a/controllers/entityParser.js
+++ b/controllers/entityParser.js
@@ -1,5 +1,14 @@
 import nlp from 'compromise'
+import { fetch as undiciFetch } from 'undici'
 import { capitalizeFirstLetter, stripPossessive } from '../helpers.js'
+import logger from './logger.js'
+
+const DEFAULT_HINTS = Object.freeze({ first: [], middle: [], last: [], suffix: [], secondary: null })
+const COMMON_LAST_SUFFIXES = [
+  'sson', 'son', 'sen', 'ez', 'es', 'is', 'os', 'as', 'ian', 'yan', 'ov', 'ova', 'ev', 'eva', 'ski', 'sky', 'stein',
+  'berg', 'ford', 'well', 'wood', 'land', 'ton', 'dson', 'dsen', 'man', 'mann', 'vich', 'vych', 'wicz', 'witz', 'escu',
+  'opoulos', 'ashvili', 'dottir'
+]
 
 export function normalizeEntity (w) {
   if (typeof w !== 'string') return ''
@@ -10,23 +19,289 @@ export function normalizeEntity (w) {
     .toLowerCase()
 }
 
-export default function entityParser (nlpInput, pluginHints = { first: [], last: [] }, timeLeft = () => Infinity) {
+function dedupeNameList (values) {
+  const seen = new Set()
+  const out = []
+  for (const value of Array.isArray(values) ? values : []) {
+    if (typeof value !== 'string') continue
+    const trimmed = value.trim()
+    if (!trimmed) continue
+    const key = normalizeEntity(trimmed)
+    if (!key || seen.has(key)) continue
+    seen.add(key)
+    out.push(trimmed)
+  }
+  return out
+}
+
+function coerceHints (rawHints) {
+  if (!rawHints || typeof rawHints !== 'object') rawHints = DEFAULT_HINTS
+  const hints = {
+    first: dedupeNameList(rawHints.first || rawHints.firstNames),
+    middle: dedupeNameList(rawHints.middle || rawHints.middleNames),
+    last: dedupeNameList(rawHints.last || rawHints.lastNames),
+    suffix: dedupeNameList(rawHints.suffix || rawHints.suffixes),
+    secondary: normalizeSecondaryConfig(rawHints.secondary)
+  }
+  return hints
+}
+
+function buildHintSets (hints) {
+  const makeSet = (list) => new Set(list.map(normalizeEntity).filter(Boolean))
+  return {
+    first: makeSet(hints.first),
+    middle: makeSet(hints.middle),
+    last: makeSet(hints.last),
+    suffix: makeSet(hints.suffix)
+  }
+}
+
+function startsWithUpper (word) {
+  return typeof word === 'string' && /^[\p{Lu}]/u.test(word.trim())
+}
+
+function likelySuffix (word, hintSets) {
+  const normalized = normalizeEntity(word)
+  if (!normalized) return false
+  if (hintSets.suffix.has(normalized)) return true
+  return /^(?:jr|sr|ii|iii|iv|phd|md|esq)$/i.test(normalized)
+}
+
+function likelyLast (word, hintSets) {
+  const normalized = normalizeEntity(word)
+  if (!normalized) return false
+  if (hintSets.last.has(normalized)) return true
+  if (COMMON_LAST_SUFFIXES.some(suffix => normalized.endsWith(suffix))) return true
+  try {
+    const doc = nlp(word)
+    if (doc.has('#LastName') || doc.has('#Surname')) return true
+  } catch {}
+  return false
+}
+
+function likelyFirst (word, hintSets) {
+  const normalized = normalizeEntity(word)
+  if (!normalized) return false
+  if (hintSets.first.has(normalized) || hintSets.middle.has(normalized)) return true
+  try {
+    const doc = nlp(word)
+    if (doc.has('#FirstName') || doc.has('#FemaleName') || doc.has('#MaleName')) return true
+  } catch {}
+  return false
+}
+
+function maybeSplitBySpacing (text) {
+  if (typeof text !== 'string') return null
+  if (!/[\s\u00A0]{2,}|[\r\n]/.test(text)) return null
+  const parts = text.split(/\s+/).map(s => s.trim()).filter(Boolean)
+  return parts.length > 1 ? parts : null
+}
+
+function splitViaSecondary (words, secondaryMap) {
+  if (!secondaryMap || secondaryMap.size === 0) return null
+  const matches = []
+  for (const word of words) {
+    const key = normalizeEntity(word)
+    if (!key) return null
+    const match = secondaryMap.get(key)
+    if (!match) return null
+    matches.push(match)
+  }
+  return matches.length > 1 ? matches : null
+}
+
+function attemptHeuristicSplit (words, hintSets) {
+  if (!Array.isArray(words) || words.length < 2) return null
+  if (!words.every(startsWithUpper)) return null
+  const suffixCount = words.filter(word => likelySuffix(word, hintSets)).length
+  if (suffixCount) return null
+  const firstCount = words.filter(word => likelyFirst(word, hintSets)).length
+  const lastCount = words.filter(word => likelyLast(word, hintSets)).length
+  if (firstCount >= 2 && lastCount === 0) {
+    return words.map(capitalizeFirstLetter)
+  }
+  return null
+}
+
+function buildSecondaryMap (names) {
+  const map = new Map()
+  for (const name of dedupeNameList(names)) {
+    const key = normalizeEntity(name)
+    if (!key || map.has(key)) continue
+    map.set(key, capitalizeFirstLetter(name))
+  }
+  return map
+}
+
+function normalizeSecondaryConfig (raw) {
+  if (!raw) return null
+  if (Array.isArray(raw)) return { people: dedupeNameList(raw) }
+  if (typeof raw === 'function') return { fetcher: raw }
+  if (typeof raw !== 'object') return null
+  const out = {}
+  if (Array.isArray(raw.people)) out.people = dedupeNameList(raw.people)
+  if (typeof raw.fetcher === 'function') out.fetcher = raw.fetcher
+  if (typeof raw.endpoint === 'string' && raw.endpoint.trim()) {
+    out.endpoint = raw.endpoint.trim()
+    if (typeof raw.method === 'string') out.method = raw.method.trim()
+    if (raw.headers && typeof raw.headers === 'object') out.headers = { ...raw.headers }
+    if (typeof raw.field === 'string' && raw.field.trim()) out.field = raw.field.trim()
+    if (Number.isFinite(Number(raw.timeoutMs))) out.timeoutMs = Number(raw.timeoutMs)
+    if (Number.isFinite(Number(raw.minConfidence))) out.minConfidence = Number(raw.minConfidence)
+  }
+  return Object.keys(out).length ? out : null
+}
+
+async function fetchSecondaryPeople (text, secondaryHints, timeLeft) {
+  if (!secondaryHints) return []
+  const timeRemaining = typeof timeLeft === 'function' ? timeLeft() : Infinity
+  if (timeRemaining <= 0) return []
+  if (Array.isArray(secondaryHints.people) && secondaryHints.people.length) {
+    return dedupeNameList(secondaryHints.people)
+  }
+  if (typeof secondaryHints.fetcher === 'function') {
+    try {
+      const res = await secondaryHints.fetcher(text)
+      return dedupeNameList(Array.isArray(res) ? res : res?.people)
+    } catch (err) {
+      logger.warn('secondary ner fetcher failed', err)
+      return []
+    }
+  }
+  if (!secondaryHints.endpoint) return []
+  const minConfidence = Number.isFinite(Number(secondaryHints.minConfidence)) ? Number(secondaryHints.minConfidence) : 0
+  const method = typeof secondaryHints.method === 'string' ? secondaryHints.method.toUpperCase() : 'POST'
+  const headers = { 'content-type': 'application/json', ...(secondaryHints.headers || {}) }
+  const field = typeof secondaryHints.field === 'string' && secondaryHints.field.trim() ? secondaryHints.field.trim() : 'text'
+  const timeoutMs = Number.isFinite(Number(secondaryHints.timeoutMs)) ? Number(secondaryHints.timeoutMs) : 2000
+  if (timeRemaining < timeoutMs * 0.75) return []
+  const controller = new AbortController()
+  const timer = setTimeout(() => controller.abort(), timeoutMs)
+  try {
+    const body = method === 'GET' ? undefined : JSON.stringify({ [field]: text })
+    const res = await undiciFetch(secondaryHints.endpoint, { method, headers, body, signal: controller.signal })
+    if (!res.ok) {
+      logger.warn('secondary ner request failed', { status: res.status })
+      return []
+    }
+    let data = null
+    try { data = await res.json() } catch (err) {
+      logger.warn('secondary ner parse failed', err)
+      return []
+    }
+    const names = extractPeopleFromSecondary(data, minConfidence)
+    return dedupeNameList(names)
+  } catch (err) {
+    if (err?.name !== 'AbortError') logger.warn('secondary ner fetch failed', err)
+    return []
+  } finally {
+    clearTimeout(timer)
+  }
+}
+
+function extractPeopleFromSecondary (data, minConfidence = 0) {
+  const out = []
+  const push = (val) => {
+    if (typeof val !== 'string') return
+    const trimmed = val.trim()
+    if (trimmed) out.push(trimmed)
+  }
+  const handleEntity = (entity) => {
+    if (!entity || typeof entity !== 'object') return
+    const label = String(entity.label || entity.label_ || entity.type || entity.category || '').toUpperCase()
+    if (label && label !== 'PERSON') return
+    const score = entity.score ?? entity.confidence ?? entity.prob ?? entity.probability
+    if (typeof score === 'number' && Number.isFinite(minConfidence) && score < minConfidence) return
+    push(entity.text || entity.name || entity.value)
+  }
+  if (!data) return out
+  if (Array.isArray(data)) {
+    for (const item of data) {
+      if (typeof item === 'string') push(item)
+      else handleEntity(item)
+    }
+    return out
+  }
+  if (typeof data !== 'object') return out
+  if (Array.isArray(data.people)) data.people.forEach(push)
+  if (Array.isArray(data.names)) data.names.forEach(push)
+  if (Array.isArray(data.ents)) data.ents.forEach(handleEntity)
+  if (Array.isArray(data.entities)) data.entities.forEach(handleEntity)
+  if (Array.isArray(data.results)) data.results.forEach(handleEntity)
+  if (Array.isArray(data.docs)) {
+    for (const doc of data.docs) {
+      if (Array.isArray(doc?.ents)) doc.ents.forEach(handleEntity)
+      if (Array.isArray(doc?.entities)) doc.entities.forEach(handleEntity)
+    }
+  }
+  if (data.entities && typeof data.entities === 'object') {
+    const personList = data.entities.PERSON || data.entities.person || data.entities.people
+    if (Array.isArray(personList)) personList.forEach(push)
+  }
+  return out
+}
+
+function maybeSplitPerson (entity, rawText, hintSets, secondaryMap) {
+  const raw = typeof rawText === 'string' ? rawText : ''
+  let fallback = raw.trim()
+  if (!fallback && typeof entity?.text === 'string') fallback = entity.text.trim()
+  if (!fallback) return []
+
+  const sanitizedFallback = fallback.replace(/\.(?=\s|$)/g, '').replace(/\s+/g, ' ').trim()
+  let canonical = sanitizedFallback
+  if (entity.person && (entity.person.honorific || entity.person.firstName || entity.person.middleName || entity.person.lastName)) {
+    const parts = [entity.person.honorific, entity.person.firstName, entity.person.middleName, entity.person.lastName]
+      .filter(Boolean)
+      .map(part => capitalizeFirstLetter(String(part).trim()))
+    const joined = parts.join(' ').replace(/\s+/g, ' ').trim()
+    if (joined && (!sanitizedFallback || sanitizedFallback === sanitizedFallback.toLowerCase())) {
+      canonical = /-/.test(entity.text) ? sanitizedFallback : joined
+    }
+  }
+  const safeCanonical = (canonical || sanitizedFallback || fallback).trim()
+
+  const normalizedLower = raw.replace(/\s+/g, ' ').toLowerCase()
+  if (/\b(?:and|or|und|et|y|e)\b/.test(normalizedLower)) return [safeCanonical]
+  if (/[\-/'’]/.test(fallback)) return [safeCanonical]
+
+  const spacingSplit = maybeSplitBySpacing(raw)
+  if (spacingSplit) return spacingSplit.map(capitalizeFirstLetter)
+
+  const words = fallback.split(/\s+/).filter(Boolean)
+  if (words.length <= 1) return [safeCanonical]
+
+  const secondarySplit = splitViaSecondary(words, secondaryMap)
+  if (secondarySplit) return secondarySplit
+
+  const heuristicSplit = attemptHeuristicSplit(words, hintSets)
+  if (heuristicSplit) return heuristicSplit
+
+  return [safeCanonical]
+}
+
+export default async function entityParser (nlpInput, pluginHints = DEFAULT_HINTS, timeLeft = () => Infinity) {
   const doc = nlp(nlpInput)
+  const hints = coerceHints(pluginHints)
+  const hintSets = buildHintSets(hints)
+
   const entityToString = (e) => {
     if (Array.isArray(e?.terms) && e.terms.length) {
-      const parts = []
+      let raw = ''
       for (let i = 0; i < e.terms.length; i++) {
         const term = e.terms[i]
-        let text = String(term.text || '').trim()
-        if (!text) continue
-        if (/^[’']s$/i.test(text) && parts.length) {
-          parts[parts.length - 1] += "'s"
-        } else {
-          const isHyphen = typeof term.post === 'string' && term.post.trim() === '-' && i < e.terms.length - 1
-          parts.push(isHyphen ? text + '-' : text)
+        const text = typeof term.text === 'string' ? term.text : ''
+        const trimmed = text.trim()
+        if (!trimmed) {
+          if (typeof term.pre === 'string') raw += term.pre
+          if (typeof term.post === 'string') raw += term.post
+          continue
         }
+        const pre = typeof term.pre === 'string' ? term.pre : (raw ? ' ' : '')
+        raw += pre + trimmed
+        if (typeof term.post === 'string') raw += term.post
       }
-      return parts.join(' ').replace(/- /g, '-').trim()
+      const cleaned = raw.trim()
+      if (cleaned) return cleaned
     }
     if (typeof e?.text === 'string') return e.text.trim()
     return null
@@ -39,47 +314,47 @@ export default function entityParser (nlpInput, pluginHints = { first: [], last:
       const str = stripPossessive(String(s || '').trim(), stripAll)
       if (!str) continue
       const key = normalizeEntity(str)
-      if (!seen.has(key)) {
-        seen.add(key)
-        out.push(capitalizeFirstLetter(str))
-      }
+      if (!key || seen.has(key)) continue
+      seen.add(key)
+      out.push(capitalizeFirstLetter(str))
     }
     return out
   }
 
+  const secondaryPeople = await fetchSecondaryPeople(nlpInput, hints.secondary, timeLeft)
+  const secondaryMap = buildSecondaryMap(secondaryPeople)
+
   const result = {}
-  // use compromise's richer person parsing to split name parts
   doc.people().parse()
-  result.people = dedupeEntities(
-    doc.people().json().map(p => {
-      const text = entityToString(p)
-      if (p.person && (p.person.honorific || p.person.firstName || p.person.middleName || p.person.lastName)) {
-        const parts = [p.person.honorific, p.person.firstName, p.person.middleName, p.person.lastName]
-          .filter(Boolean)
-          .map(capitalizeFirstLetter)
-        const joined = parts.join(' ')
-        // preserve hyphenated names using original text
-        return /-/.test(p.text) ? text : joined
-      }
-      return text
-    }),
-    true
-  )
-  const seen = new Set(result.people.map(p => normalizeEntity(p)))
-  if (pluginHints.first.length && pluginHints.last.length) {
+  const compromisePeople = doc.people().json().flatMap(p => {
+    const text = entityToString(p)
+    if (!text) return []
+    return maybeSplitPerson(p, text, hintSets, secondaryMap)
+  })
+
+  let combinedPeople = compromisePeople
+  if (secondaryPeople.length) combinedPeople = combinedPeople.concat(secondaryPeople)
+
+  let people = dedupeEntities(combinedPeople, true)
+  const seen = new Set(people.map(name => normalizeEntity(name)))
+
+  if (hints.first.length && hints.last.length) {
     const haystack = normalizeEntity(nlpInput)
-    for (const f of pluginHints.first) {
-      for (const l of pluginHints.last) {
+    for (const f of hints.first) {
+      for (const l of hints.last) {
         const raw = `${f} ${l}`
         const key = normalizeEntity(raw)
         if (haystack.includes(key) && !seen.has(key)) {
-          result.people.push(capitalizeFirstLetter(raw))
+          people.push(capitalizeFirstLetter(raw))
           seen.add(key)
         }
       }
     }
   }
-  result.people = dedupeEntities(result.people, true)
+
+  people = dedupeEntities(people, true)
+  result.people = people
+
   if (timeLeft() >= 1000) result.places = dedupeEntities(doc.places().json().map(entityToString))
   if (timeLeft() >= 900) result.orgs = dedupeEntities(doc.organizations().json().map(entityToString))
   if (timeLeft() >= 800) result.topics = dedupeEntities(doc.topics().json().map(entityToString))

--- a/controllers/nlpPlugins.js
+++ b/controllers/nlpPlugins.js
@@ -1,21 +1,97 @@
 import nlp from 'compromise'
 import logger from './logger.js'
 
+const DEFAULT_HINTS = Object.freeze({ first: [], middle: [], last: [], suffix: [], secondary: null })
+
+function normalizeName (value) {
+  if (typeof value !== 'string') return ''
+  return value
+    .replace(/[’']/g, '')
+    .replace(/[^A-Za-z0-9-]+/g, ' ')
+    .trim()
+    .toLowerCase()
+}
+
+function sanitizeSecondaryConfig (raw) {
+  if (!raw) return null
+  if (Array.isArray(raw)) return { people: dedupeList(raw) }
+  if (typeof raw === 'function') return { fetcher: raw }
+  if (typeof raw !== 'object') return null
+  const out = {}
+  if (Array.isArray(raw.people)) out.people = dedupeList(raw.people)
+  if (typeof raw.fetcher === 'function') out.fetcher = raw.fetcher
+  if (typeof raw.endpoint === 'string' && raw.endpoint.trim()) {
+    out.endpoint = raw.endpoint.trim()
+    if (typeof raw.method === 'string') out.method = raw.method.trim()
+    if (raw.headers && typeof raw.headers === 'object') out.headers = { ...raw.headers }
+    if (typeof raw.field === 'string' && raw.field.trim()) out.field = raw.field.trim()
+    if (Number.isFinite(Number(raw.timeoutMs))) out.timeoutMs = Number(raw.timeoutMs)
+    if (Number.isFinite(Number(raw.minConfidence))) out.minConfidence = Number(raw.minConfidence)
+  }
+  return Object.keys(out).length ? out : null
+}
+
+function dedupeList (values) {
+  const out = []
+  const seen = new Set()
+  for (const value of Array.isArray(values) ? values : []) {
+    if (typeof value !== 'string') continue
+    const trimmed = value.trim()
+    if (!trimmed) continue
+    const key = normalizeName(trimmed)
+    if (!key || seen.has(key)) continue
+    seen.add(key)
+    out.push(trimmed)
+  }
+  return out
+}
+
+function addHint (bucket, value, hints, sets) {
+  if (typeof value !== 'string') return
+  const trimmed = value.trim()
+  if (!trimmed) return
+  const key = normalizeName(trimmed)
+  if (!key || sets[bucket].has(key)) return
+  sets[bucket].add(key)
+  hints[bucket].push(trimmed)
+}
+
+function mergeValues (values, bucket, hints, sets) {
+  for (const value of Array.isArray(values) ? values : []) addHint(bucket, value, hints, sets)
+}
+
 export function loadNlpPlugins (options) {
-  const hints = { first: [], last: [] }
-  if (!options?.nlp?.plugins?.length) return hints
-  for (const plugin of options.nlp.plugins) {
+  const hints = { ...DEFAULT_HINTS, first: [], middle: [], last: [], suffix: [], secondary: null }
+  const sets = { first: new Set(), middle: new Set(), last: new Set(), suffix: new Set() }
+
+  const directHints = options?.nlp?.hints
+  if (directHints) {
+    mergeValues(directHints.first, 'first', hints, sets)
+    mergeValues(directHints.middle, 'middle', hints, sets)
+    mergeValues(directHints.last, 'last', hints, sets)
+    mergeValues(directHints.suffix, 'suffix', hints, sets)
+  }
+
+  if (options?.nlp?.secondary) hints.secondary = sanitizeSecondaryConfig(options.nlp.secondary)
+
+  const plugins = Array.isArray(options?.nlp?.plugins) ? options.nlp.plugins : []
+  for (const plugin of plugins) {
     try { nlp.plugin(plugin) } catch (err) { logger.warn('nlp plugin load failed', err) }
     try {
       plugin(null, {
         addWords: (words = {}) => {
-          for (const [w, tag] of Object.entries(words)) {
-            if (/^first/i.test(tag)) hints.first.push(w)
-            else if (/^last/i.test(tag)) hints.last.push(w)
+          for (const [word, tag] of Object.entries(words)) {
+            if (!tag) continue
+            const normalizedTag = String(tag).toLowerCase()
+            if (normalizedTag.startsWith('first')) addHint('first', word, hints, sets)
+            else if (normalizedTag.startsWith('middle')) addHint('middle', word, hints, sets)
+            else if (normalizedTag.startsWith('suffix')) addHint('suffix', word, hints, sets)
+            else if (normalizedTag.startsWith('last')) addHint('last', word, hints, sets)
           }
         }
       })
     } catch (err) { logger.warn('nlp plugin init failed', err) }
   }
+
   return hints
 }

--- a/index.js
+++ b/index.js
@@ -130,7 +130,7 @@ const articleParser = async function (browser, options, socket) {
   article.processed = {}
   article.processed.text = {}
   article.lighthouse = {}
-  const pluginHints = options.__pluginHints || { first: [], last: [] }
+  const pluginHints = options.__pluginHints || { first: [], middle: [], last: [], suffix: [], secondary: null }
 
   const log = (phase, msg, fields = {}) => {
     try {
@@ -1228,7 +1228,7 @@ log('analyze', 'Evaluating meta tags')
       try {
         log('analyze', 'Extracting named entities')
         if (timeLeft() < 1200) { log('analyze', 'Skipping NER due to low budget'); return }
-        const entities = entityParser(cleanAnalysisInput, pluginHints, timeLeft)
+        const entities = await entityParser(cleanAnalysisInput, pluginHints, timeLeft)
         Object.assign(article, entities)
         try {
           const pc = Array.isArray(article.people) ? article.people.length : 0

--- a/tests/entityParser.test.js
+++ b/tests/entityParser.test.js
@@ -1,10 +1,11 @@
 import { test } from 'node:test'
 import assert from 'node:assert/strict'
 import entityParser from '../controllers/entityParser.js'
+import { loadNlpPlugins } from '../controllers/nlpPlugins.js'
 
-test('entityParser capitalizes extracted entities', () => {
+test('entityParser capitalizes extracted entities', async () => {
   const input = 'john doe went to paris. google and microsoft.'
-  const res = entityParser(input, { first: [], last: [] }, () => 2000)
+  const res = await entityParser(input, { first: [], last: [] }, () => 2000)
   const arrays = [res.people, res.places, res.orgs, res.topics]
   for (const arr of arrays) {
     if (Array.isArray(arr)) {
@@ -15,9 +16,9 @@ test('entityParser capitalizes extracted entities', () => {
   }
 })
 
-test("entityParser removes trailing possessive 's", () => {
+test("entityParser removes trailing possessive 's", async () => {
   const input = "Angela's phone was found in Paris's museum run by Google's team"
-  const res = entityParser(input, { first: [], last: [] }, () => 2000)
+  const res = await entityParser(input, { first: [], last: [] }, () => 2000)
   assert.deepEqual(res.people, ['Angela'])
   assert.deepEqual(res.places, ['Paris'])
   assert.deepEqual(res.orgs, ['Google'])
@@ -26,32 +27,86 @@ test("entityParser removes trailing possessive 's", () => {
   assert(!res.orgs?.some(o => /'s$/i.test(o)))
 })
 
-test("entityParser strips possessive for multi-word people", () => {
+test("entityParser strips possessive for multi-word people", async () => {
   const input = "Mr Trump's visit impressed Mrs May's supporters"
-  const res = entityParser(input, { first: [], last: [] }, () => 2000)
+  const res = await entityParser(input, { first: [], last: [] }, () => 2000)
   assert(res.people.includes('Mr Trump'))
   assert(res.people.includes('Mrs May'))
   assert(!res.people.some(p => /'s$/i.test(p)))
 })
 
-test("entityParser strips possessive for multi-word entities", () => {
+test("entityParser strips possessive for multi-word entities", async () => {
   const input = "The United States's economy continues to grow"
-  const res = entityParser(input, { first: [], last: [] }, () => 2000)
+  const res = await entityParser(input, { first: [], last: [] }, () => 2000)
   assert(res.places.includes('United States'))
   assert(res.topics.includes('United States'))
   assert(!res.places.some(p => /'s$/i.test(p)))
   assert(!res.topics.some(t => /'s$/i.test(t)))
 })
 
-test("entityParser handles possessive places with trailing punctuation", () => {
+test("entityParser handles possessive places with trailing punctuation", async () => {
   const input = "He returned from New Zealand's."
-  const res = entityParser(input, { first: [], last: [] }, () => 2000)
+  const res = await entityParser(input, { first: [], last: [] }, () => 2000)
   assert(res.places.includes('New Zealand'))
   assert(!res.places.some(p => /['’]s/i.test(p)))
 })
 
-test('entityParser preserves hyphenated names', () => {
+test('entityParser preserves hyphenated names', async () => {
   const input = 'Jean-Luc Picard met Jean-Luc Picard'
-  const res = entityParser(input, { first: [], last: [] }, () => 2000)
+  const res = await entityParser(input, { first: [], last: [] }, () => 2000)
   assert(res.people.includes('Jean-Luc Picard'))
+})
+
+test('entityParser splits adjacent names using secondary hints', async () => {
+  const input = 'John Mary arrived together.'
+  const res = await entityParser(input, { first: [], last: [], secondary: { people: ['John', 'Mary'] } }, () => 2000)
+  assert.deepEqual(res.people, ['John', 'Mary'])
+})
+
+test('entityParser falls back when secondary service fails', async () => {
+  const input = 'Alice Johnson outlined the plan.'
+  const res = await entityParser(input, {
+    first: [],
+    last: [],
+    secondary: {
+      fetcher: async () => { throw new Error('service down') }
+    }
+  }, () => 2000)
+  assert(res.people.includes('Alice Johnson'))
+})
+
+test('entityParser respects middle and suffix hints for complex names', async () => {
+  const input = 'Dr. José Luis Rodríguez Jr. met Ana María López in Madrid.'
+  const hints = {
+    first: ['José', 'Ana'],
+    middle: ['Luis', 'María'],
+    last: ['Rodríguez', 'López'],
+    suffix: ['Jr']
+  }
+  const res = await entityParser(input, hints, () => 2000)
+  assert(res.people.some(name => /José Luis Rodríguez Jr/.test(name)))
+  assert(res.people.some(name => /Ana María López/.test(name)))
+})
+
+test('loadNlpPlugins collects extended hints and secondary config', () => {
+  const plugin = (_Doc, world) => {
+    world.addWords({
+      Carlos: 'FirstName',
+      Ramirez: 'LastName',
+      Jr: 'Suffix'
+    })
+  }
+  const hints = loadNlpPlugins({
+    nlp: {
+      plugins: [plugin],
+      hints: { middle: ['Luis'] },
+      secondary: { endpoint: 'https://ner.example/api', method: 'post' }
+    }
+  })
+  assert(hints.first.includes('Carlos'))
+  assert(hints.last.includes('Ramirez'))
+  assert(hints.middle.includes('Luis'))
+  assert(hints.suffix.includes('Jr'))
+  assert.equal(hints.secondary.endpoint, 'https://ner.example/api')
+  assert.equal(hints.secondary.method, 'post')
 })


### PR DESCRIPTION
## Summary
- add support for middle/suffix hints, secondary NER integration, and smarter splitting in the entity parser
- extend the NLP plugin loader and documentation to cover new hint buckets and optional service configuration
- ensure inline wrapper removal preserves spacing and add regression tests for the updated behavior

## Testing
- npm test *(fails: Puppeteer/Chrome dependencies unavailable in container)*

------
https://chatgpt.com/codex/tasks/task_e_68c89b0ea4a8833298084c174c0043a3