### PR TITLE
Improve people extraction from acknowledgement lists

### DIFF
--- a/tests/entityParser.test.js
+++ b/tests/entityParser.test.js
@@ -88,6 +88,24 @@ test('entityParser respects middle and suffix hints for complex names', async ()
   assert(res.people.some(name => /Ana María López/.test(name)))
 })
 
+test('entityParser extracts acknowledgement name lists', async () => {
+  const input = `Acknowledgements: Borja Balle, Zachary Charles, Christopher A. Choquette-Choo, Lynn Chua, Badih Ghazi, Da Yu, Chiyuan Zhang.`
+  const res = await entityParser(input, { first: [], last: [] }, () => 2000)
+  const expected = [
+    'Borja Balle',
+    'Zachary Charles',
+    'Christopher A Choquette-Choo',
+    'Lynn Chua',
+    'Badih Ghazi',
+    'Da Yu',
+    'Chiyuan Zhang'
+  ]
+  for (const name of expected) {
+    assert(res.people.includes(name))
+  }
+  assert(!res.people.includes('Christopher'))
+})
+
 test('loadNlpPlugins collects extended hints and secondary config', () => {
   const plugin = (_Doc, world) => {
     world.addWords({


### PR DESCRIPTION
## Summary
- adjust entityParser heuristics to split capitalised name lists and ignore product names
- handle newline-separated enumerations without breaking multi-word names
- add a regression test covering acknowledgement lists of contributors

## Testing
- npm test *(fails for Puppeteer-based suites: missing Chrome system libraries)*

------
https://chatgpt.com/codex/tasks/task_e_68c92ef0b20083329a4c1c989f794b87