### PR TITLE
Improve dense acknowledgement name splitting

### DIFF
--- a/tests/entityParser.test.js
+++ b/tests/entityParser.test.js
@@ -142,6 +142,17 @@ test('entityParser splits acknowledgement runs without punctuation', async () =>
   assert(!res.people.some(name => /Kairouz Brendan McMahan/.test(name)))
 })
 
+test('entityParser keeps dense acknowledgements together when surnames are unknown', async () => {
+  const input = 'Thanks to John Qwerty Mary Asdf for their help.'
+  const res = await entityParser(input, { first: [], last: [] }, () => 2000)
+  assert(res.people.includes('John Qwerty'))
+  assert(res.people.includes('Mary Asdf'))
+  assert(!res.people.includes('John'))
+  assert(!res.people.includes('Qwerty'))
+  assert(!res.people.includes('Mary'))
+  assert(!res.people.includes('Asdf'))
+})
+
 test('loadNlpPlugins collects extended hints and secondary config', () => {
   const plugin = (_Doc, world) => {
     world.addWords({


### PR DESCRIPTION
## Summary
- tighten heuristic splitting to avoid returning single-word entries for dense acknowledgement blocks
- merge honorific-prefixed fragments with following names and drop leading honorifics when parsing long runs
- mark entire dense sequences for removal once split so fallback blobs disappear
- add regression test to ensure dense acknowledgements with unknown surnames stay paired

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c94d6aa9d883328f0b3f5e91a35640