### PR TITLE
Handle punctuation-separated acknowledgement names

### DIFF
--- a/tests/entityParser.test.js
+++ b/tests/entityParser.test.js
@@ -106,6 +106,21 @@ test('entityParser extracts acknowledgement name lists', async () => {
   assert(!res.people.includes('Christopher'))
 })
 
+test('entityParser splits acknowledgement lists separated by semicolons', async () => {
+  const input = `Thanks to Zachary Charles; Christopher A. Choquette-Choo; Lynn Chua; Peter Kairouz.`
+  const res = await entityParser(input, { first: [], last: [] }, () => 2000)
+  const expected = [
+    'Zachary Charles',
+    'Christopher A Choquette-Choo',
+    'Lynn Chua',
+    'Peter Kairouz'
+  ]
+  for (const name of expected) {
+    assert(res.people.includes(name), `${name} not found in ${JSON.stringify(res.people)}`)
+  }
+  assert(!res.people.some(name => /Zachary Charles Christopher/.test(name)))
+})
+
 test('entityParser splits acknowledgement runs without punctuation', async () => {
   const input = `Thanks to Peter Kairouz Brendan McMahan Dan Ramage Mark Simborg Kimberly Schwede Borja Balle Zachary Charles Christopher A. Choquette-Choo Lynn Chua Prem Eruvbetine Badih Ghazi Steve He Yangsibo Huang Armand Joulin George Kaissis Pritish Kamath Ravi Kumar Daogao Liu Ruibo Liu Pasin Manurangsi Thomas Mesnard Andreas Terzis Tris Warkentin Da Yu Chiyuan Zhang.`
   const res = await entityParser(input, { first: [], last: [] }, () => 2000)


### PR DESCRIPTION
## Summary
- allow acknowledgement name extraction to treat semicolons and similar punctuation as separators
- reuse a shared name-splitting helper to apply heuristics per punctuation chunk and avoid merged people
- add a regression test covering semicolon-separated acknowledgement lists

## Testing
- npm test --silent

------
https://chatgpt.com/codex/tasks/task_e_68c959f1c8a483328aea81c3ae4b6171