### PR TITLE
Trim job titles from people names

### DIFF
--- a/tests/entityParser.test.js
+++ b/tests/entityParser.test.js
@@ -45,6 +45,13 @@ test("entityParser strips possessive for multi-word entities", async () => {
   assert(!res.topics.some(t => /'s$/i.test(t)))
 })
 
+test('entityParser trims comma-delimited role descriptors', async () => {
+  const input = 'At the event, Tres Wong-Godfrey Tech Lead at Cisco Meraki was featured. Later, Tres Wong-Godfrey, Tech Lead at Cisco Meraki, offered insights.'
+  const res = await entityParser(input, { first: [], last: [] }, () => 2000)
+  assert(res.people.includes('Tres Wong-Godfrey'))
+  assert(!res.people.some(name => /Tres Wong-Godfrey\s+Tech/i.test(name)))
+})
+
 test("entityParser handles possessive places with trailing punctuation", async () => {
   const input = "He returned from New Zealand's."
   const res = await entityParser(input, { first: [], last: [] }, () => 2000)


### PR DESCRIPTION
## Summary
- add comma-aware helpers in `entityParser` so trailing job titles are dropped while leaving real multi-name lists intact【F:controllers/entityParser.js†L170-L308】
- update `maybeSplitPerson` to apply the new trimming logic using the full article context and adjust the caller accordingly【F:controllers/entityParser.js†L835-L913】【F:controllers/entityParser.js†L960-L966】
- add a regression test to ensure comma-delimited role descriptors no longer appear in extracted people names【F:tests/entityParser.test.js†L48-L53】

## Testing
- `npm test`【960885†L1-L38】
- `npm run sample:single -- --timeout 60000` *(fails: Timeout budget exceeded while fetching the BBC article)*【843142†L1-L20】

------
https://chatgpt.com/codex/tasks/task_e_68c9c956c17083328a5d983e07bd9227