### PR TITLE
Improve job title trimming for entity parser

### DIFF
--- a/tests/entityParser.test.js
+++ b/tests/entityParser.test.js
@@ -52,6 +52,22 @@ test('entityParser trims comma-delimited role descriptors', async () => {
   assert(!res.people.some(name => /Tres Wong-Godfrey\s+Tech/i.test(name)))
 })
 
+test('entityParser trims inline role descriptors without punctuation cues', async () => {
+  const input = 'Speaker Tres Wong-Godfrey Tech Lead at Cisco Meraki shared updates with the crowd.'
+  const res = await entityParser(input, { first: [], last: [] }, () => 2000)
+  assert(res.people.includes('Tres Wong-Godfrey'))
+  assert(!res.people.some(name => /Tres Wong-Godfrey\s+Tech/i.test(name)))
+})
+
+test('entityParser removes trailing multi-word job titles', async () => {
+  const input = 'Our gratitude goes to Alice Johnson Senior Product Manager for Slack and Bob Smith Founder and CEO of Example Corp.'
+  const res = await entityParser(input, { first: [], last: [] }, () => 2000)
+  assert(res.people.includes('Alice Johnson'))
+  assert(res.people.includes('Bob Smith'))
+  assert(!res.people.some(name => /Alice Johnson\s+Senior/i.test(name)))
+  assert(!res.people.some(name => /Bob Smith\s+Founder/i.test(name)))
+})
+
 test("entityParser handles possessive places with trailing punctuation", async () => {
   const input = "He returned from New Zealand's."
   const res = await entityParser(input, { first: [], last: [] }, () => 2000)


### PR DESCRIPTION
## Summary
- add job title heuristics so `trimTrailingNonNameWords` can recognise job descriptors even when commas are missing
- ensure job title tokens are removed from extracted people names and add regression tests for inline descriptors

## Testing
- npm test
- npm run sample:single -- --url https://openai.com/index/introducing-upgrades-to-codex/ *(fails with 403 from site)*

------
https://chatgpt.com/codex/tasks/task_e_68c9d31dfc4483328c92c87fb2c71778